### PR TITLE
Add edit_mode config option (vi/emacs keybindings)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,7 @@ confirm_ai_commands = true               # show command before executing (defaul
 auto_correct_typos = true                # suggest corrections for near-miss commands
 history_context_lines = 20               # recent commands included in AI context
 safety_mode = "warn"                     # "warn" | "block" | "off"
+edit_mode = "emacs"                      # "emacs" (default) or "vi"
 
 # --- Fish compatibility ---
 
@@ -119,6 +120,7 @@ gs = "git status -sb"
 | `auto_correct_typos` | boolean | `true` | Offer typo corrections for near-miss commands |
 | `history_context_lines` | integer | `20` | Number of recent commands sent to AI for context |
 | `safety_mode` | string | `"warn"` | `"warn"` shows warnings, `"block"` prevents execution, `"off"` disables |
+| `edit_mode` | string | `"emacs"` | `"emacs"` (default) or `"vi"` for vi-style keybindings |
 
 ## Per-Project Config (`.shako.toml`)
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -63,6 +63,8 @@ pub struct BehaviorConfig {
     pub history_context_lines: usize,
     #[serde(default = "default_safety_mode")]
     pub safety_mode: String,
+    #[serde(default = "default_edit_mode")]
+    pub edit_mode: String,
 }
 
 #[derive(Debug, Default, Deserialize, Clone)]
@@ -109,6 +111,10 @@ fn default_safety_mode() -> String {
     "warn".to_string()
 }
 
+fn default_edit_mode() -> String {
+    "emacs".to_string()
+}
+
 impl Default for LlmConfig {
     fn default() -> Self {
         Self {
@@ -130,6 +136,7 @@ impl Default for BehaviorConfig {
             auto_correct_typos: true,
             history_context_lines: 20,
             safety_mode: "warn".to_string(),
+            edit_mode: "emacs".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use std::io::{self, Write};
 
 use anyhow::Result;
 use reedline::{
-    ColumnarMenu, Emacs, FileBackedHistory, KeyCode, KeyModifiers, MenuBuilder, Reedline,
-    ReedlineEvent, ReedlineMenu, Signal, default_emacs_keybindings,
+    ColumnarMenu, EditMode, Emacs, FileBackedHistory, KeyCode, KeyModifiers, MenuBuilder, Reedline,
+    ReedlineEvent, ReedlineMenu, Signal, Vi, default_emacs_keybindings,
 };
 
 mod ai;
@@ -99,22 +99,25 @@ fn main() -> Result<()> {
             .with_column_padding(2),
     );
 
-    let mut keybindings = default_emacs_keybindings();
-    keybindings.add_binding(
-        KeyModifiers::NONE,
-        KeyCode::Tab,
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Menu("completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
-        ]),
-    );
-    keybindings.add_binding(
-        KeyModifiers::SHIFT,
-        KeyCode::BackTab,
-        ReedlineEvent::MenuPrevious,
-    );
-
-    let edit_mode = Box::new(Emacs::new(keybindings));
+    let edit_mode: Box<dyn EditMode> = if config.behavior.edit_mode == "vi" {
+        Box::new(Vi::default())
+    } else {
+        let mut keybindings = default_emacs_keybindings();
+        keybindings.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Tab,
+            ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::Menu("completion_menu".to_string()),
+                ReedlineEvent::MenuNext,
+            ]),
+        );
+        keybindings.add_binding(
+            KeyModifiers::SHIFT,
+            KeyCode::BackTab,
+            ReedlineEvent::MenuPrevious,
+        );
+        Box::new(Emacs::new(keybindings))
+    };
 
     let mut line_editor = Reedline::create()
         .with_history(history)


### PR DESCRIPTION
## Summary

- Adds `[behavior] edit_mode = "emacs" | "vi"` config option
- When set to `"vi"`, uses reedline's native Vi mode with full normal/insert/visual mode support
- Default remains `"emacs"` with existing Tab/Shift-Tab completion bindings

Closes #23

## Test plan

- [x] `cargo test` — 54 passing
- [x] `cargo clippy` — 0 warnings
- [ ] Manual: set `edit_mode = "vi"` in config.toml, verify Esc/i/a/hjkl work
- [ ] Manual: verify default "emacs" mode + Tab completion still works


💘 Generated with Crush