### PR TITLE
docs: add quick-reference crib sheet, update docs and ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A fish-inspired shell where natural language and shell commands coexist. Type `l
 cargo build --release
 make install        # installs to ~/.local/bin/shako
 shako               # first run launches interactive setup wizard
+shako -c "ls -la"   # non-interactive: run one command and exit
 ```
 
 ## How It Works
@@ -59,11 +60,12 @@ Every input is classified in order:
 
 | Guide | What's covered |
 |---|---|
+| [Quick Reference](docs/quick-reference.md) | Cheat sheet — syntax, modes, aliases, keybindings |
 | [Getting Started](docs/getting-started.md) | Installation, first run, configuration wizard |
 | [AI Features](docs/ai-features.md) | Translation, explain mode, error recovery, project context |
+| [Shell Features](docs/shell-features.md) | Builtins, pipes, redirects, job control, functions, history |
 | [Smart Defaults](docs/smart-defaults.md) | Tool detection, auto-aliases, AI tool preferences |
 | [Configuration](docs/configuration.md) | Full config reference, LLM providers, behavior settings |
-| [Shell Features](docs/shell-features.md) | Builtins, pipes, redirects, job control, functions, history |
 | [ROADMAP](ROADMAP.md) | Planned features and architecture improvements |
 | [SCOPE](SCOPE.md) | Original design document |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,25 +6,29 @@ Living document tracking gaps, bugs, feature ideas, and priorities for making sh
 
 ## Bugs / Broken Wiring
 
-- [ ] **Stderr never captured for AI diagnosis** — `main.rs` calls `diagnose_error()` with `""` for stderr. The AI can't see *why* a command failed. Capture stderr from child processes and pass it through.
-- [ ] **`history_context_lines` declared but never used** — `config/schema.rs` has the field (marked `dead_code`), but it's never read. AI should see recent command history for follow-up queries.
-- [ ] **`pre_exec` collision on `2>&1`** — `apply_stderr_redirect()` calls `cmd.pre_exec()` which *replaces* the one set by `setup_child_signals()`. Commands with `2>&1` lose signal handling (SIGINT/SIGQUIT/SIGTSTP not reset to defaults in child). Fix: merge both closures into a single `pre_exec`.
+- [x] **Stderr never captured for AI diagnosis** — fixed; `execute_command_with_stderr` captures stderr and passes last 20 lines to `diagnose_error()`.
+- [x] **`history_context_lines` declared but never used** — fixed; `read_recent_history()` now reads this from config and passes to AI context on every query.
+- [x] **`pre_exec` collision on `2>&1`** — fixed; `setup_child_signals()` combines setpgid and stderr-dup into a single `pre_exec` closure. Comment in `executor.rs` documents the fix.
 
 ---
 
 ## Quick Wins (high value, low effort)
 
-- [ ] **Git context for AI** — send current branch, dirty/clean status, and recent `git log --oneline -5` to the AI. Most AI queries are git-related.
-- [ ] **Project type detection** — detect `Cargo.toml`, `package.json`, `go.mod`, `pyproject.toml`, `Makefile`, `Dockerfile`, etc. in cwd and tell the AI what ecosystem tools to use.
-- [ ] **More smart defaults** — detect and alias:
-  - `duf` → `df` (disk usage with colors)
-  - `ouch` → auto-detect for compress/decompress
-  - `tokei` → `cloc` (code statistics)
-  - `doggo` → `dig` (DNS lookup)
-  - `xh` → `curl` (HTTP client)
-  - Git shortcuts: `gs` → `git status`, `gl` → `git log --oneline -20`, `gd` → `git diff`, `gp` → `git push`
-  - Docker shortcuts: `dps` → `docker ps`, `dex` → `docker exec -it`
-  - rg-powered: `rgf` → `rg -l` (filenames only)
+- [x] **Git context for AI** — branch, dirty/clean status, and recent commits are sent to the AI on every query.
+- [x] **Project type detection** — detects `Cargo.toml`, `package.json`, `go.mod`, `pyproject.toml`, `Makefile`, `Dockerfile` in cwd and informs the AI which ecosystem tools to use.
+- [x] **More smart defaults** — the following are now detected and aliased:
+  - `duf` → `df`
+  - `tokei` → `cloc`
+  - `doggo` → `dig`
+  - `xh` → `curl`
+  - `delta` → `diff`
+  - `procs` → `ps`
+  - `btop` / `bottom` → `top`
+  - Git shortcuts: `gs`, `gl`, `gd`, `gp`, `gpl`, `gco`, `gcm`
+  - Docker shortcuts: `dps`, `dex`, `dlog`
+  - rg-powered: `rgf` → `rg -l`
+- [x] **`edit_mode` config option** — `"emacs"` (default) or `"vi"` keybindings via `[behavior] edit_mode`.
+- [x] **`-c` flag** — `shako -c "command"` runs a command non-interactively and exits.
 - [ ] **More subcommand completions** — `npm`/`pnpm`/`yarn`/`bun`, `brew`, `go`, `just` (parse justfile targets like Makefile), `python`/`pip`/`uv`, `rustup`, `terraform`, `helm`.
 - [ ] **SSH host completion** — parse `~/.ssh/config` for hostnames on `ssh <Tab>`.
 
@@ -88,9 +92,10 @@ Living document tracking gaps, bugs, feature ideas, and priorities for making sh
 
 ### Context Improvements
 
-- [ ] **Wire up `history_context_lines`** — send recent command history to the AI so it can understand "do that again" or follow-up queries.
-- [ ] **Git state in AI context** — branch, dirty/clean, recent commits.
-- [ ] **Project type in AI context** — detect build system / language from files in cwd.
+- [x] **Wire up `history_context_lines`** — recent command history is now sent to the AI on every query.
+- [x] **Git state in AI context** — branch, dirty/clean, recent commits included in every AI prompt.
+- [x] **Project type in AI context** — build system / language detected from files in cwd.
+- [x] **Per-project AI context (`.shako.toml`)** — drop a `.shako.toml` in any project root with `[ai] context = "..."` to inject project-specific instructions into every prompt.
 - [ ] **Shell aliases in AI context** — AI should know what `ll`, `gs`, etc. map to.
 - [ ] **File sizes in directory context** — useful for size-related queries.
 - [ ] **Running processes** — useful for "kill the node process" queries.
@@ -106,15 +111,15 @@ Living document tracking gaps, bugs, feature ideas, and priorities for making sh
 
 ### Innovation Ideas (differentiators)
 
-- [ ] **`?` suffix for inline explain** — `git rebase -i?` explains the flag without executing. Different from `? git rebase -i` which translates NL.
-- [ ] **Session memory** — AI remembers the conversation. After `fd *.log`, say `"now delete the ones over 1GB"` and it knows what you mean.
-- [ ] **AI-powered history search** — `? what was that rsync command I used last week` does semantic search over shell history.
-- [ ] **Proactive suggestions** — after `git add .`, suggest `git commit -m "..."` with an AI-generated message from the staged diff.
-- [ ] **Per-project AI context (`.shako.toml`)** — drop a file in your project root with instructions the AI reads:
+- [x] **`?` suffix for inline explain** — `git rebase -i?` explains the flags without executing. Implemented and working.
+- [x] **Per-project AI context (`.shako.toml`)** — drop a file in your project root with instructions the AI reads:
   ```toml
   [ai]
   context = "Rust project using actix-web. Tests: cargo nextest run."
   ```
+- [ ] **Session memory** — AI remembers the conversation. After `fd *.log`, say `"now delete the ones over 1GB"` and it knows what you mean.
+- [ ] **AI-powered history search** — `? what was that rsync command I used last week` does semantic search over shell history.
+- [ ] **Proactive suggestions** — after `git add .`, suggest `git commit -m "..."` with an AI-generated message from the staged diff.
 - [ ] **AI pipe builder** — `? take output.json, extract emails, sort unique, count` builds the pipeline step-by-step with intermediate previews.
 - [ ] **Watch-and-learn** — when the user edits an AI suggestion, log the correction to a local preferences file. Over time: "user prefers rg over grep", "user uses fd not find".
 - [ ] **Smart history search** — `? what was that command I used to resize images` does semantic search.
@@ -155,7 +160,6 @@ Missing config options for power users:
 
 | Category | Option | Purpose |
 |---|---|---|
-| Behavior | `vi_mode` / `edit_mode` | Enable vi keybindings (reedline supports this) |
 | Behavior | `history_size` | Currently hardcoded to 10,000 |
 | Behavior | `history_dedup` | Deduplicate consecutive identical commands |
 | AI | `ai_enabled` | Global kill switch for AI features |
@@ -166,6 +170,8 @@ Missing config options for power users:
 | Shell | `abbreviations` section | Define abbreviations in config file |
 | Smart Defaults | `smart_defaults_enabled` | Disable auto-aliasing entirely |
 | Smart Defaults | `smart_defaults_exclude` | Skip specific tool upgrades |
+
+> `edit_mode` (emacs/vi keybindings) is implemented — see `[behavior] edit_mode` in the [Configuration guide](docs/configuration.md).
 
 ---
 
@@ -205,26 +211,26 @@ Missing config options for power users:
 
 ## Suggested Priority Order
 
-### Phase 1 — Fix What's Broken
-1. Fix `pre_exec` collision on `2>&1`
-2. Capture stderr for AI diagnosis
-3. Wire up `history_context_lines`
+### Phase 1 — Fix What's Broken ✅ Complete
+1. ~~Fix `pre_exec` collision on `2>&1`~~ — done
+2. ~~Capture stderr for AI diagnosis~~ — done
+3. ~~Wire up `history_context_lines`~~ — done
 
 ### Phase 2 — Essential Shell Features
 4. `echo`, `read`, `test` builtins
 5. `${VAR:-default}` parameter expansion
 6. `pushd`/`popd`/`dirs`
-7. Git branch + state in AI context
+7. ~~Git branch + state in AI context~~ — done
 
 ### Phase 3 — UX Polish
-8. More smart defaults (duf, ouch, git shortcuts)
+8. ~~More smart defaults (duf, git shortcuts, docker shortcuts)~~ — done
 9. `npm`/`brew`/`go`/`just` completions
 10. Stream AI responses
 11. `[w]hy` option in AI confirmation
 
 ### Phase 4 — Differentiators
-12. `?` suffix explain mode
-13. Per-project `.shako.toml` AI context
+12. ~~`?` suffix explain mode~~ — done
+13. ~~Per-project `.shako.toml` AI context~~ — done
 14. Session memory for AI
 15. AI-powered history search
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,6 +88,7 @@ History is stored at the platform data directory:
 |---|---|
 | `--quiet` / `-q` | Suppress startup banner |
 | `--init` | Re-run the setup wizard (resets config) |
+| `-c "cmd"` | Run command non-interactively and exit |
 
 ## Next Steps
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -1,0 +1,345 @@
+# shako Quick Reference
+
+A concise cheat sheet for daily use. Print it, pin it, paste it somewhere handy.
+
+---
+
+## AI Modes
+
+| What you type | What happens |
+|---|---|
+| `show me disk usage by folder` | Auto-detected as natural language → AI translates → confirm → run |
+| `? show me disk usage` | Force AI mode (explicit prefix) |
+| `ai: show me disk usage` | Force AI mode (alternate prefix) |
+| `grep -rn?` | Explain what `-rn` flags do (no execution) |
+| `? grep` | Explain what `grep` does (single known command → explain) |
+| `chmod 755?` | Explain what `chmod 755` means |
+| `? squash the last 3 commits` | AI translates → `git rebase -i HEAD~3` → confirm |
+
+**Confirmation prompt:** `[Y]es / [n]o / [e]dit`  
+Press `Y` or Enter to run, `n` to cancel, `e` to edit the command first.
+
+---
+
+## Shell Builtins
+
+| Command | What it does |
+|---|---|
+| `cd [dir]` | Change directory. `cd -` returns to previous directory |
+| `z <query>` | Smart jump (zoxide) — `z proj` → most-visited project dir |
+| `zi` | Interactive directory picker (zoxide + fzf) |
+| `exit` | Exit shako |
+| `export KEY=value` | Set environment variable (POSIX style) |
+| `set -x KEY value` | Set and export variable (fish style) |
+| `set -gx KEY value` | Global export (fish style) |
+| `set -e KEY` | Erase/unset variable (fish style) |
+| `set` | List all environment variables |
+| `unset KEY` | Remove environment variable |
+| `alias name=value` | Define alias. `alias` alone lists all |
+| `unalias name` | Remove alias. `unalias -a` clears all |
+| `abbr add name value` | Add abbreviation (fish-style) |
+| `abbr -e name` | Remove abbreviation |
+| `abbr` | List abbreviations |
+| `history [N]` | Show last N history entries (default 25) |
+| `source file` | Load aliases, exports, functions from a file |
+| `type name` | Show how a name resolves (builtin/function/alias/PATH) |
+| `function name() { body }` | Define a shell function |
+| `functions` | List all defined functions |
+| `jobs` | List background jobs |
+| `fg [%N]` | Bring job N to foreground |
+| `bg [%N]` | Resume stopped job in background |
+| `fish-import` | Import aliases/env/functions from `~/.config/fish/` |
+
+---
+
+## History Expansion
+
+```bash
+!!           # repeat last command
+sudo !!      # run last command with sudo
+echo !$      # insert last argument of last command
+```
+
+---
+
+## Pipes, Redirects, and Chains
+
+```bash
+# Pipes
+ls | grep foo | wc -l
+
+# Stdout redirects
+cmd > file.txt       # overwrite
+cmd >> file.txt      # append
+
+# Stdin redirect
+cmd < input.txt
+
+# Stderr redirects
+cmd 2> errors.log    # stderr to file
+cmd 2>&1             # merge stderr into stdout
+cmd > out.log 2> err.log  # separate files
+cmd 2>&1 | grep err  # pipe combined output
+
+# Chains
+cmd1 && cmd2         # run cmd2 only if cmd1 succeeds
+cmd1 || cmd2         # run cmd2 only if cmd1 fails
+cmd1; cmd2; cmd3     # run all regardless of exit codes
+```
+
+---
+
+## Quoting and Expansion
+
+```bash
+echo "hello $USER"         # double quotes: variable expansion works
+echo 'no $expansion'       # single quotes: everything literal
+echo hello\ world          # backslash escapes the space
+
+echo $HOME                 # env var expansion
+echo ${USER}               # braced form
+echo $?                    # last exit code
+
+echo $(date)               # command substitution
+echo `whoami`              # backtick substitution
+echo $(dirname $(pwd))     # nested substitution
+
+ls *.rs                    # glob expansion
+ls "*.rs"                  # suppressed inside quotes
+cd ~/projects              # tilde expansion
+```
+
+---
+
+## Background Jobs
+
+```bash
+sleep 100 &    # start in background
+jobs           # list running background jobs
+fg %1          # bring job 1 to foreground
+bg %1          # resume stopped job in background
+```
+
+---
+
+## Multiline Input
+
+```bash
+echo hello \       # trailing backslash → continues on next line
+world
+
+echo "this is      # unclosed quote → continues
+a multiline string"
+```
+
+The prompt changes to `... ` for continuation lines.
+
+---
+
+## Non-Interactive Mode
+
+```bash
+shako -c "ls -la"                      # run a single command and exit
+shako -c "git status && git diff"      # run a chain
+```
+
+---
+
+## Runtime Flags
+
+| Flag | Effect |
+|---|---|
+| `--quiet` / `-q` | Suppress the startup banner |
+| `--init` | Re-run the setup wizard |
+| `-c "cmd"` | Run command non-interactively and exit |
+
+---
+
+## Smart Aliases (auto-created if tool is installed)
+
+### Modern tool upgrades
+
+| If you have | Typing this | Runs this |
+|---|---|---|
+| eza | `ls` | `eza --icons --group-directories-first` |
+| bat | `cat` | `bat --style=auto` |
+| fd | `find` | `fd` |
+| ripgrep | `grep` | `rg` |
+| dust | `du` | `dust` |
+| procs | `ps` | `procs` |
+| sd | `sed` | `sd` |
+| delta | `diff` | `delta` |
+| btop/bottom | `top` | `btop` or `btm` |
+| duf | `df` | `duf` |
+| doggo | `dig` | `doggo` |
+| xh | `curl` | `xh` |
+| tokei | `cloc` | `tokei` |
+
+### Compound aliases (eza)
+
+| Alias | Expands to |
+|---|---|
+| `ll` | `eza -la --icons --group-directories-first` |
+| `la` | `eza -a --icons --group-directories-first` |
+| `lt` | `eza --tree --icons --level=2` |
+
+### Git shortcuts
+
+| Alias | Expands to |
+|---|---|
+| `gs` | `git status` |
+| `gl` | `git log --oneline -20` |
+| `gd` | `git diff` |
+| `gp` | `git push` |
+| `gpl` | `git pull` |
+| `gco` | `git checkout` |
+| `gcm` | `git commit -m` |
+
+### Docker shortcuts
+
+| Alias | Expands to |
+|---|---|
+| `dps` | `docker ps` |
+| `dex` | `docker exec -it` |
+| `dlog` | `docker logs -f` |
+
+---
+
+## Explain Mode (`?`)
+
+```bash
+git rebase -i?        # explain git rebase -i flags
+tar xzf?              # explain tar xzf
+? grep                # explain what grep is
+? kubectl             # explain what kubectl is
+```
+
+---
+
+## Error Recovery
+
+When a command fails (exit code ≥ 2), shako offers AI help:
+
+```
+$ cargo build --featurse serde
+error: unexpected argument '--featurse'
+shako: command failed (exit 2). ask AI for help? [y/N] y
+  cause: Typo — '--featurse' should be '--features'
+  fix:   cargo build --features serde
+  [Y]es / [n]o / [e]dit:
+```
+
+Note: exit code 1 is skipped (too common — grep no-match, test failure). Press **Enter at the `[y/N]`** to skip (default is no).
+
+---
+
+## Per-Project AI Context
+
+Drop a `.shako.toml` in any project root to give the AI project-specific instructions:
+
+```toml
+[ai]
+context = """
+Rust project using actix-web and SQLx.
+Tests: cargo nextest run
+Database: PostgreSQL on localhost:5433
+Deploy: make deploy-staging
+"""
+```
+
+The AI reads this every time you're in that directory.
+
+---
+
+## Tab Completion
+
+Subcommand completions for: `git`, `cargo`, `docker`, `podman`, `kubectl`, `make`, `gmake`, `sudo`, `cd`, `z`, `pushd`.
+
+All `$PATH` executables, builtins, and file paths complete too. Filenames with spaces are auto-escaped.
+
+---
+
+## Syntax Highlighting
+
+As you type, shako colors the input:
+
+| Element | Color |
+|---|---|
+| Valid command | **Green** (bold) |
+| Shell builtin | **Cyan** (bold) |
+| AI prefix (`?`, `ai:`) | **Purple** (bold) |
+| Explicit path | Yellow |
+| Unknown command | Red |
+| Flags (`-x`, `--flag`) | Blue |
+| Strings | Yellow |
+| Pipes and redirects | Cyan |
+| Variables (`$VAR`) | Green |
+| Comments (`# ...`) | Gray (italic) |
+
+---
+
+## Autosuggestions
+
+Gray inline suggestions from history appear as you type.
+
+- **Right arrow** — accept full suggestion
+- **Ctrl+Right** — accept one word
+
+---
+
+## Config File
+
+`~/.config/shako/config.toml` — key options:
+
+```toml
+active_provider = "work_proxy"
+
+[providers.work_proxy]
+endpoint = "https://llm-proxy.company.com"
+model = "claude-sonnet-4.5"
+api_key_env = "LLMPROXY_KEY"
+
+[behavior]
+confirm_ai_commands = true       # [Y/n/e] before running AI commands
+auto_correct_typos = true        # typo suggestion prompt
+history_context_lines = 20       # recent commands sent to AI
+safety_mode = "warn"             # "warn" | "block" | "off"
+edit_mode = "emacs"              # "emacs" | "vi"
+```
+
+---
+
+## Signal Handling
+
+| Key | Effect |
+|---|---|
+| `Ctrl-C` | Interrupt foreground process |
+| `Ctrl-\\` | Quit foreground process (SIGQUIT) |
+| `Ctrl-Z` | Suspend foreground process |
+| `Ctrl-D` | Exit shell (on empty line) |
+
+---
+
+## Startup Files
+
+| File | Purpose |
+|---|---|
+| `~/.config/shako/config.toml` | Main config (providers, behavior, aliases) |
+| `~/.config/shako/config.shako` | Startup script (aliases, exports, functions) |
+| `~/.config/shako/conf.d/*.sh` | Config snippets, sourced alphabetically |
+| `~/.config/shako/functions/*.sh` | Autoloaded functions (name must match filename) |
+| `~/.config/shako/starship.toml` | shako-specific Starship prompt config |
+
+History: `~/Library/Application Support/shako/history.txt` (macOS) or `~/.local/share/shako/history.txt` (Linux)
+
+---
+
+## See Also
+
+| Guide | What's covered |
+|---|---|
+| [Getting Started](getting-started.md) | Installation, setup wizard, directory structure |
+| [AI Features](ai-features.md) | Translation, explain mode, error recovery, context |
+| [Shell Features](shell-features.md) | Builtins, pipes, redirects, job control, functions |
+| [Smart Defaults](smart-defaults.md) | Auto-aliasing, tool detection, AI tool awareness |
+| [Configuration](configuration.md) | Full config reference, multi-provider setup |

--- a/docs/shell-features.md
+++ b/docs/shell-features.md
@@ -140,6 +140,18 @@ a multiline string"           # until the quote is closed
 
 The prompt changes to `... ` for continuation lines.
 
+## Non-Interactive Mode
+
+Run a single command and exit without starting the REPL:
+
+```bash
+shako -c "ls -la"
+shako -c "git status && git diff"
+shako -c "make build"
+```
+
+Useful in scripts or when you need shako's parsing (quoting, expansion, aliases) without an interactive session.
+
 ## Functions
 
 Define functions inline or in files:


### PR DESCRIPTION
Comprehensive documentation pass. Adds docs/quick-reference.md crib sheet for new users covering AI modes, builtins, shell syntax, aliases, keybindings, config, and startup files. Updates README, getting-started, shell-features with -c flag docs. Updates ROADMAP to mark completed items (bugs fixed, features shipped).