### PR TITLE
feat: add [w]hy option to AI confirmation prompt

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -9,7 +9,7 @@ Type what you want in plain English. shako translates it to a shell command, sho
 ```
 $ show me the 10 largest files in this directory
 ❯ fd --type f -x stat -f '%z %N' {} | sort -rn | head -10
-[Y]es / [n]o / [e]dit:
+[Y]es / [n]o / [e]dit / [w]hy:
 ```
 
 The AI is **tool-aware** — it knows which modern tools you have installed and prefers them:
@@ -36,6 +36,7 @@ After the AI generates a command:
 - **`Y` or Enter** — execute the command
 - **`n`** — cancel
 - **`e`** — edit the command before executing (type your corrected version)
+- **`w`** — explain what the command does, then re-present the prompt
 
 ### Safety Layer
 
@@ -89,7 +90,7 @@ error: unexpected argument '--featurse'
 shako: command failed (exit 2). ask AI for help? [y/N] y
   cause: Typo in flag name — '--featurse' should be '--features'
   fix: cargo build --features serde
-  [Y]es / [n]o / [e]dit:
+  [Y]es / [n]o / [e]dit / [w]hy:
 ```
 
 The AI receives:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -16,8 +16,8 @@ A concise cheat sheet for daily use. Print it, pin it, paste it somewhere handy.
 | `chmod 755?` | Explain what `chmod 755` means |
 | `? squash the last 3 commits` | AI translates → `git rebase -i HEAD~3` → confirm |
 
-**Confirmation prompt:** `[Y]es / [n]o / [e]dit`  
-Press `Y` or Enter to run, `n` to cancel, `e` to edit the command first.
+**Confirmation prompt:** `[Y]es / [n]o / [e]dit / [w]hy`  
+Press `Y` or Enter to run, `n` to cancel, `e` to edit the command first, `w` to get an explanation before deciding.
 
 ---
 
@@ -226,7 +226,7 @@ error: unexpected argument '--featurse'
 shako: command failed (exit 2). ask AI for help? [y/N] y
   cause: Typo — '--featurse' should be '--features'
   fix:   cargo build --features serde
-  [Y]es / [n]o / [e]dit:
+  [Y]es / [n]o / [e]dit / [w]hy:
 ```
 
 Note: exit code 1 is skipped (too common — grep no-match, test failure). Press **Enter at the `[y/N]`** to skip (default is no).

--- a/src/ai/confirm.rs
+++ b/src/ai/confirm.rs
@@ -5,13 +5,14 @@ pub enum ConfirmAction {
     Execute,
     Edit(String),
     Cancel,
+    Why,
 }
 
 /// Show the AI-translated command and ask user to confirm, edit, or cancel.
 pub fn confirm_command(command: &str) -> Result<ConfirmAction> {
     // Show the translated command with color
     println!("\x1b[36m❯\x1b[0m \x1b[1m{command}\x1b[0m");
-    print!("\x1b[90m[Y]es / [n]o / [e]dit:\x1b[0m ");
+    print!("\x1b[90m[Y]es / [n]o / [e]dit / [w]hy:\x1b[0m ");
     io::stdout().flush()?;
 
     let mut input = String::new();
@@ -33,6 +34,7 @@ pub fn confirm_command(command: &str) -> Result<ConfirmAction> {
                 Ok(ConfirmAction::Edit(edited))
             }
         }
+        "w" | "why" => Ok(ConfirmAction::Why),
         _ => Ok(ConfirmAction::Cancel),
     }
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -41,15 +41,31 @@ pub async fn translate_and_execute(
         if extra_warning {
             eprintln!("\x1b[33;1m⚠ this command modifies system state\x1b[0m");
         }
-        match confirm::confirm_command(command)? {
-            confirm::ConfirmAction::Execute => {
-                crate::executor::execute_command(command);
-            }
-            confirm::ConfirmAction::Edit(edited) => {
-                crate::executor::execute_command(&edited);
-            }
-            confirm::ConfirmAction::Cancel => {
-                println!("cancelled");
+        loop {
+            match confirm::confirm_command(command)? {
+                confirm::ConfirmAction::Execute => {
+                    crate::executor::execute_command(command);
+                    break;
+                }
+                confirm::ConfirmAction::Edit(edited) => {
+                    crate::executor::execute_command(&edited);
+                    break;
+                }
+                confirm::ConfirmAction::Cancel => {
+                    println!("cancelled");
+                    break;
+                }
+                confirm::ConfirmAction::Why => {
+                    match explain_command(command, config).await {
+                        Ok(explanation) => {
+                            println!("\x1b[90m{explanation}\x1b[0m");
+                        }
+                        Err(e) => {
+                            eprintln!("shako: couldn't explain: {e}");
+                        }
+                    }
+                    // loop continues — re-shows the command and prompt
+                }
             }
         }
     } else {


### PR DESCRIPTION
Phase 3: adds a [w]hy option to the AI command confirmation UX. When the user presses w, shako explains the generated command in plain English, then re-presents the prompt so the user can still choose to run, edit, or cancel. Updates docs/quick-reference.md and docs/ai-features.md.