### PR TITLE
feat: stream AI responses live to terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,7 +399,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1121,6 +1148,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1141,12 +1169,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1368,6 +1398,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "env_logger",
+ "futures-util",
  "glob",
  "libc",
  "log",
@@ -1614,6 +1645,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1872,6 +1916,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crossterm = "0.29"
 tokio = { version = "1", features = ["full"] }
 
 # HTTP client (for LLM API)
-reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots", "rustls-tls-webpki-roots"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots", "rustls-tls-webpki-roots", "stream"], default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -53,6 +53,7 @@ glob = "0.3"
 
 # ANSI terminal styling (used by reedline highlighter/hinter)
 nu-ansi-term = "0.50"
+futures-util = "0.3"
 
 # Nix (Unix process control, signals)
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/src/ai/client.rs
+++ b/src/ai/client.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
+use std::io::Write;
 
 use anyhow::Result;
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 
 use crate::config::LlmConfig;
@@ -11,6 +13,7 @@ struct ChatRequest {
     messages: Vec<ChatMessage>,
     max_tokens: u32,
     temperature: f32,
+    stream: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -27,6 +30,22 @@ struct ChatResponse {
 #[derive(Deserialize)]
 struct ChatChoice {
     message: ChatMessage,
+}
+
+// Streaming response types (SSE)
+#[derive(Deserialize)]
+struct StreamDelta {
+    content: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StreamChoice {
+    delta: StreamDelta,
+}
+
+#[derive(Deserialize)]
+struct StreamResponse {
+    choices: Vec<StreamChoice>,
 }
 
 /// Normalize an endpoint URL: ensure it has a scheme and the chat completions path.
@@ -50,6 +69,8 @@ pub fn normalize_endpoint(endpoint: &str) -> String {
 }
 
 /// Query the configured LLM endpoint with OpenAI-compatible API.
+/// Streams tokens to stdout as they arrive. Falls back to non-streaming
+/// parse if the server ignores `stream: true` and returns plain JSON.
 /// Retries once on transient network errors with a short delay.
 pub async fn query_llm(
     system_prompt: &str,
@@ -80,6 +101,7 @@ pub async fn query_llm(
         ],
         max_tokens: config.max_tokens,
         temperature: config.temperature,
+        stream: true,
     };
 
     let mut last_err = None;
@@ -103,11 +125,61 @@ pub async fn query_llm(
                     return Err(anyhow::anyhow!("LLM API {endpoint} returned {status}: {body}"));
                 }
 
-                let chat_response: ChatResponse = response.json().await?;
+                // Collect raw bytes while streaming SSE tokens to stdout
+                let mut stream = response.bytes_stream();
+                let mut full_text = String::new();
+                let mut raw_bytes = Vec::new();
+                let mut buf = String::new();
+                let mut done = false;
+
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk?;
+                    raw_bytes.extend_from_slice(&chunk);
+                    buf.push_str(&String::from_utf8_lossy(&chunk));
+
+                    // Process complete lines
+                    while let Some(nl) = buf.find('\n') {
+                        let line = buf[..nl].trim().to_string();
+                        buf = buf[nl + 1..].to_string();
+
+                        if line.starts_with("data: ") {
+                            let data = &line["data: ".len()..];
+                            if data == "[DONE]" {
+                                done = true;
+                                break;
+                            }
+                            if let Ok(chunk_resp) = serde_json::from_str::<StreamResponse>(data) {
+                                if let Some(choice) = chunk_resp.choices.first() {
+                                    if let Some(content) = &choice.delta.content {
+                                        print!("{content}");
+                                        let _ = std::io::stdout().flush();
+                                        full_text.push_str(content);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if done {
+                        break;
+                    }
+                }
+
+                if !full_text.is_empty() {
+                    // Streaming worked — emit trailing newline for the confirm prompt
+                    println!();
+                    return Ok(full_text.trim().to_string());
+                }
+
+                // Fallback: server returned plain JSON instead of SSE
+                log::debug!("stream yielded no content, falling back to non-streaming parse");
+                let body = String::from_utf8_lossy(&raw_bytes);
+                let chat_response: ChatResponse = serde_json::from_str(&body)
+                    .map_err(|e| anyhow::anyhow!("failed to parse LLM response: {e}\nbody: {body}"))?;
                 return chat_response
                     .choices
                     .first()
-                    .map(|c| c.message.content.clone())
+                    .map(|c| c.message.content.trim().to_string())
                     .ok_or_else(|| anyhow::anyhow!("no response from LLM"));
             }
             Err(e) => {


### PR DESCRIPTION
Phase 3: LLM tokens now print progressively as they arrive rather than blocking until the full response is ready. Uses SSE streaming via reqwest bytes_stream(). Falls back to non-streaming JSON parse for servers that ignore stream: true.