### PR TITLE
feat: proactive git commit message suggestion after git add

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -94,6 +94,18 @@ pub async fn diagnose_error(
     client::query_llm(&system_prompt, &user_msg, config.active_llm()).await
 }
 
+/// Generate a git commit message for the currently staged changes.
+///
+/// `stat` is the output of `git diff --staged --stat`.
+/// `diff` is the output of `git diff --staged` (may be truncated).
+pub async fn suggest_commit(stat: &str, diff: &str, config: &ShakoConfig) -> Result<String> {
+    let system_prompt = prompt::commit_message_prompt();
+    let user_msg = format!("Staged changes summary:\n{stat}\nFull diff:\n{diff}");
+    let raw = client::query_llm(&system_prompt, &user_msg, config.active_llm()).await?;
+    // Strip any wrapping quotes the model might add
+    Ok(raw.trim().trim_matches('"').trim_matches('\'').to_string())
+}
+
 /// Explain what a command does without executing it.
 pub async fn explain_command(
     command: &str,

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -121,6 +121,28 @@ Rules:
     prompt
 }
 
+/// Build the system prompt for generating a git commit message.
+pub fn commit_message_prompt() -> String {
+    r#"You are a git commit message generator.
+
+Given a staged diff summary and the actual diff, write a single concise commit message.
+
+Rules:
+1. Use conventional commits format: type(scope): description
+   Valid types: feat, fix, refactor, docs, test, chore, style, perf, ci, build
+2. The description must be ≤72 characters total, imperative mood ("add" not "added")
+3. Return ONLY the commit message. No quotes, no explanation, no markdown, no code fences.
+4. Omit the scope if it would be too generic (e.g. do not write "chore(misc):")
+5. If changes span multiple unrelated concerns, summarize the most significant one.
+6. Good examples:
+   feat(auth): add OAuth2 login flow
+   fix(parser): handle empty input without panic
+   refactor: extract ShellState into separate module
+   docs: update README with new CLI flags
+   test: add integration tests for pipe chains"#
+        .to_string()
+}
+
 /// Build the system prompt for explaining a command.
 pub fn explain_prompt(ctx: &ShellContext) -> String {
     format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod executor;
 mod fish_import;
 mod parser;
 mod path_cache;
+mod proactive;
 mod safety;
 mod setup;
 mod shell;
@@ -353,6 +354,8 @@ fn main() -> Result<()> {
                                     &rt,
                                     &history_path,
                                 );
+                            } else {
+                                proactive::check(&cmd, &config, &rt);
                             }
                         }
                     }

--- a/src/proactive.rs
+++ b/src/proactive.rs
@@ -1,0 +1,201 @@
+//! Proactive suggestions — offered automatically after certain commands succeed.
+//!
+//! Currently implemented:
+//!   - After `git add`, offer an AI-generated commit message.
+
+use std::io::{self, Write};
+use std::process::Command;
+
+use crate::ai;
+use crate::config::ShakoConfig;
+use crate::executor;
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Called after every successful foreground command. Checks whether a
+/// proactive suggestion is appropriate and, if so, offers it to the user.
+pub fn check(cmd: &str, config: &ShakoConfig, rt: &tokio::runtime::Runtime) {
+    if is_git_add(cmd) {
+        offer_commit_suggestion(config, rt);
+    }
+}
+
+// ── git add → commit message ──────────────────────────────────────────────────
+
+/// Returns true for `git add <anything>` that actually stages files.
+/// Excludes `git add --help`, `git add --version`, and bare `git add`.
+fn is_git_add(cmd: &str) -> bool {
+    let mut tokens = cmd.split_whitespace();
+    match (tokens.next(), tokens.next(), tokens.next()) {
+        (Some("git"), Some("add"), Some(arg)) => {
+            !arg.starts_with("--help") && !arg.starts_with("--version")
+        }
+        _ => false,
+    }
+}
+
+struct StagedInfo {
+    /// `git diff --staged --stat` output (human-readable summary).
+    stat: String,
+    /// `git diff --staged` output, capped at 4 KB.
+    diff: String,
+    /// Number of changed files reported in the stat.
+    file_count: usize,
+}
+
+/// Run `git diff --staged` and collect info about what's staged.
+/// Returns `None` when not in a git repo, nothing is staged, or git fails.
+fn get_staged_info() -> Option<StagedInfo> {
+    let stat_out = Command::new("git")
+        .args(["diff", "--staged", "--stat"])
+        .output()
+        .ok()?;
+
+    if !stat_out.status.success() {
+        return None;
+    }
+
+    let stat = String::from_utf8_lossy(&stat_out.stdout).to_string();
+    if stat.trim().is_empty() {
+        return None; // nothing staged
+    }
+
+    // Count lines that describe a changed file (contain "|" or "Bin")
+    let file_count = stat
+        .lines()
+        .filter(|l| l.contains('|') || l.contains("Bin "))
+        .count();
+
+    // Get the actual diff for richer AI context, capped to keep prompt size sane
+    let diff_out = Command::new("git")
+        .args(["diff", "--staged"])
+        .output()
+        .ok()?;
+
+    let full_diff = String::from_utf8_lossy(&diff_out.stdout).to_string();
+    const DIFF_CAP: usize = 4_000;
+    let diff = if full_diff.len() > DIFF_CAP {
+        format!("{}\n[...diff truncated at {DIFF_CAP} bytes...]", &full_diff[..DIFF_CAP])
+    } else {
+        full_diff
+    };
+
+    Some(StagedInfo { stat, diff, file_count })
+}
+
+/// Offer an AI-generated commit message to the user.
+fn offer_commit_suggestion(config: &ShakoConfig, rt: &tokio::runtime::Runtime) {
+    let Some(staged) = get_staged_info() else {
+        return;
+    };
+
+    let file_word = if staged.file_count == 1 { "file" } else { "files" };
+    print!(
+        "\x1b[90mshako: {} {} staged — suggest a commit message? [y/N] \x1b[0m",
+        staged.file_count, file_word
+    );
+    io::stdout().flush().ok();
+
+    let mut answer = String::new();
+    if io::stdin().read_line(&mut answer).is_err() {
+        return;
+    }
+
+    if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+        return;
+    }
+
+    // Show a spinner while the AI thinks
+    print!("\x1b[90mthinking...\x1b[0m");
+    io::stdout().flush().ok();
+
+    let result = rt.block_on(ai::suggest_commit(&staged.stat, &staged.diff, config));
+
+    // Clear the spinner line
+    print!("\r\x1b[K");
+    io::stdout().flush().ok();
+
+    match result {
+        Ok(message) => {
+            let commit_cmd = format!("git commit -m {}", shell_quote(&message));
+            loop {
+                match ai::confirm::confirm_command(&commit_cmd) {
+                    Ok(ai::confirm::ConfirmAction::Execute) => {
+                        executor::execute_command(&commit_cmd);
+                        break;
+                    }
+                    Ok(ai::confirm::ConfirmAction::Edit(edited)) => {
+                        executor::execute_command(&edited);
+                        break;
+                    }
+                    Ok(ai::confirm::ConfirmAction::Cancel) => break,
+                    Ok(ai::confirm::ConfirmAction::Why) => {
+                        // Show what's staged as the "why"
+                        eprintln!("\x1b[90m{}\x1b[0m", staged.stat.trim());
+                        // loop continues — re-shows the command and prompt
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+        Err(e) => eprintln!("shako: couldn't suggest commit message: {e}"),
+    }
+}
+
+/// Quote a string safely for use as a shell argument.
+fn shell_quote(s: &str) -> String {
+    if !s.contains('"') {
+        format!("\"{s}\"")
+    } else if !s.contains('\'') {
+        format!("'{s}'")
+    } else {
+        // Escape double quotes inside double-quoted string
+        format!("\"{}\"", s.replace('"', "\\\""))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_git_add_basic() {
+        assert!(is_git_add("git add ."));
+        assert!(is_git_add("git add -A"));
+        assert!(is_git_add("git add src/main.rs"));
+        assert!(is_git_add("git add -p"));
+        assert!(is_git_add("git add --patch"));
+    }
+
+    #[test]
+    fn test_is_git_add_excluded() {
+        assert!(!is_git_add("git add"));           // no target
+        assert!(!is_git_add("git add --help"));
+        assert!(!is_git_add("git add --version"));
+        assert!(!is_git_add("git commit -m test"));
+        assert!(!is_git_add("git status"));
+        assert!(!is_git_add("echo hello"));
+    }
+
+    #[test]
+    fn test_shell_quote_no_special() {
+        assert_eq!(shell_quote("feat: add login"), r#""feat: add login""#);
+    }
+
+    #[test]
+    fn test_shell_quote_has_double_quotes() {
+        // falls back to single quotes when message contains "
+        assert_eq!(shell_quote(r#"fix: handle "empty" input"#), r#"'fix: handle "empty" input'"#);
+    }
+
+    #[test]
+    fn test_shell_quote_has_both_quotes() {
+        let msg = r#"it's a "fix""#;
+        let quoted = shell_quote(msg);
+        // should use escaped double quotes
+        assert!(quoted.starts_with('"'));
+        assert!(quoted.contains(r#"\""#));
+    }
+}


### PR DESCRIPTION
Closes #43

## Summary

After a successful `git add`, shako offers an AI-generated commit message based on the staged diff — zero friction, opt-in with a single keystroke.

```
$ git add src/main.rs src/proactive.rs
shako: 2 files staged — suggest a commit message? [y/N] y
thinking...
❯ git commit -m "feat: add proactive git commit suggestion after git add"
[Y]es / [n]o / [e]dit / [w]hy:
```

- Default is **[N]o** — one enter key skips it completely
- **[w]hy** shows the staged stat so you know exactly what's included
- **[e]dit** lets you tweak the message before committing
- Commit message follows conventional commits format (feat/fix/refactor/docs/…)
- Diff is capped at 4 KB before being sent to the AI

## Implementation

- `src/proactive.rs` — new module; `check()` is called after every successful foreground command, currently only triggers on `git add`
- `ai::suggest_commit()` + `prompt::commit_message_prompt()` — new AI function with a tight commit-message-focused system prompt
- `proactive::shell_quote()` — safely wraps commit messages containing `"` or `'`
- Hook in `main.rs`: one `else` branch after the existing `offer_ai_recovery` check

## Test plan

- [x] 89 tests pass (59 unit + 30 integration)
- [x] `cargo clippy -- -W warnings` clean (pre-existing warning in client.rs unrelated to this change)
- [x] 5 new unit tests: `is_git_add` variants, `shell_quote` edge cases
- [x] `git add --help` and bare `git add` do NOT trigger the prompt
- [x] Nothing staged → no prompt (get_staged_info returns None)
- [x] Not in a git repo → no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)