### PR TITLE
feat: validate AI session on startup

### DIFF
--- a/src/ai/client.rs
+++ b/src/ai/client.rs
@@ -200,6 +200,83 @@ pub async fn query_llm(
     ))
 }
 
+/// Result of the startup AI session probe.
+pub enum AiCheckResult {
+    Ready,
+    Disabled,
+    NoApiKey(String),
+    AuthFailed(u16),
+    Unreachable(String),
+}
+
+/// Probe the configured LLM endpoint at startup and return its status.
+/// Hits `GET /v1/models` with a 3-second timeout — fast enough not to stall startup.
+pub async fn check_ai_session(config: &crate::config::LlmConfig, ai_enabled: bool) -> AiCheckResult {
+    if !ai_enabled {
+        return AiCheckResult::Disabled;
+    }
+
+    let api_key = std::env::var(&config.api_key_env).unwrap_or_default();
+    let endpoint = normalize_endpoint(&config.endpoint);
+
+    // Derive the /v1/models URL from the same origin as the chat endpoint.
+    let models_url = match endpoint.parse::<reqwest::Url>() {
+        Ok(parsed) => {
+            let origin = match parsed.port() {
+                Some(port) => format!(
+                    "{}://{}:{}",
+                    parsed.scheme(),
+                    parsed.host_str().unwrap_or("localhost"),
+                    port
+                ),
+                None => format!(
+                    "{}://{}",
+                    parsed.scheme(),
+                    parsed.host_str().unwrap_or("localhost")
+                ),
+            };
+            format!("{origin}/v1/models")
+        }
+        Err(_) => return AiCheckResult::Unreachable("invalid endpoint URL".to_string()),
+    };
+
+    // Warn early about a missing API key for non-local endpoints.
+    let is_local = models_url.contains("localhost") || models_url.contains("127.0.0.1");
+    if api_key.is_empty() && !is_local {
+        return AiCheckResult::NoApiKey(config.api_key_env.clone());
+    }
+
+    let client = match reqwest::Client::builder()
+        .danger_accept_invalid_certs(!config.verify_ssl)
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return AiCheckResult::Unreachable(e.to_string()),
+    };
+
+    let mut req = client.get(&models_url);
+    if !api_key.is_empty() {
+        req = req.bearer_auth(&api_key);
+    }
+
+    match req.send().await {
+        Ok(resp) => match resp.status().as_u16() {
+            200..=299 => AiCheckResult::Ready,
+            401 | 403 => AiCheckResult::AuthFailed(resp.status().as_u16()),
+            code => AiCheckResult::Unreachable(format!("HTTP {code}")),
+        },
+        Err(e) => {
+            let reason = if e.is_connect() || e.is_timeout() {
+                "endpoint unreachable".to_string()
+            } else {
+                e.to_string()
+            };
+            AiCheckResult::Unreachable(reason)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,9 +111,15 @@ fn main() -> Result<()> {
     }
 
     let (config, first_run) = ShakoConfig::load()?;
+    let rt = tokio::runtime::Runtime::new()?;
 
     if !quiet {
         print_banner(&config);
+        let ai_status = rt.block_on(ai::client::check_ai_session(
+            config.active_llm(),
+            config.behavior.ai_enabled,
+        ));
+        print_ai_status(&ai_status, config.active_llm());
     }
 
     if first_run {
@@ -176,7 +182,6 @@ fn main() -> Result<()> {
         .with_edit_mode(edit_mode);
 
     let prompt = StarshipPrompt::new();
-    let rt = tokio::runtime::Runtime::new()?;
     let mut state = ShellState::new(history_path.clone());
 
     // Interactive shell signal setup.
@@ -806,6 +811,31 @@ fn print_banner(config: &ShakoConfig) {
          \x1b[33m{provider_name}\x1b[0m  {model}  \x1b[90m{endpoint_display}\x1b[0m",
         model = llm.model,
     );
+}
+
+fn print_ai_status(status: &ai::client::AiCheckResult, llm: &config::LlmConfig) {
+    match status {
+        ai::client::AiCheckResult::Ready => {
+            eprintln!("\x1b[90m  AI\x1b[0m  \x1b[32m✓ session ready\x1b[0m");
+        }
+        ai::client::AiCheckResult::Disabled => {}
+        ai::client::AiCheckResult::NoApiKey(env_var) => {
+            eprintln!(
+                "\x1b[90m  AI\x1b[0m  \x1b[33m⚠ no API key\x1b[0m  \x1b[90m({env_var} not set — AI will be unavailable)\x1b[0m"
+            );
+        }
+        ai::client::AiCheckResult::AuthFailed(code) => {
+            eprintln!(
+                "\x1b[90m  AI\x1b[0m  \x1b[31m✗ auth failed\x1b[0m  \x1b[90m(HTTP {code} — check {})\x1b[0m",
+                llm.api_key_env
+            );
+        }
+        ai::client::AiCheckResult::Unreachable(reason) => {
+            eprintln!(
+                "\x1b[90m  AI\x1b[0m  \x1b[31m✗ unreachable\x1b[0m  \x1b[90m({reason})\x1b[0m"
+            );
+        }
+    }
 }
 
 /// Infer a friendly backend label from an endpoint URL.


### PR DESCRIPTION
## Summary

- Adds `check_ai_session` in `ai/client.rs` that probes `GET /v1/models` with a 3-second timeout
- Prints a status line below the banner at shell start:
  - `✓ session ready` (green) — endpoint reachable and responding
  - `⚠ no API key` (yellow) — non-local endpoint with no key set
  - `✗ auth failed` (red) — HTTP 401/403
  - `✗ unreachable` (red) — connection refused or timeout
- Moves tokio runtime creation before the banner so the async check runs in startup sequence
- Suppressed with `--quiet` and when `ai_enabled = false` in config

## Test plan

- [ ] Start shako with a running local LLM — confirm green `✓ session ready`
- [ ] Start with endpoint down — confirm red `✗ unreachable` within ~3s
- [ ] Start with remote endpoint and no API key set — confirm yellow `⚠ no API key`
- [ ] Start with wrong API key — confirm red `✗ auth failed (HTTP 401)`
- [ ] Start with `--quiet` — confirm no AI status line printed
- [ ] Set `ai_enabled = false` in config — confirm no status line printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)