### PR TITLE
feat: implement /command slash command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ $ gti status                      # typo → "did you mean git status? [Y/n]"
 $ gcc bad.c                       # fails → "ask AI for help? [y/N]" → suggests fix
 $ git add .                       # → proactive: "commit with this message? [Y/n/e]"
 $ z projects                      # zoxide smart jump
+$ /validate                       # slash command → validate AI endpoint
+$ /safety off                     # slash command → change safety mode (session)
 ```
 
 Every input is classified in order:
@@ -36,10 +38,11 @@ Every input is classified in order:
 2. `??` prefix → AI-powered history search
 3. `?` or `ai:` prefix → AI mode (explain if bare command, translate otherwise)
 4. Trailing `?` → explain command without executing
-5. Builtin (`cd`, `exit`, `z`, `set`, etc.) → handle internally
-6. Found in `$PATH` → execute directly (unless args look like prose → AI)
-7. Close to a known command → typo suggestion
-8. Everything else → AI translation
+5. `/word` → slash command (shako meta-commands)
+6. Builtin (`cd`, `exit`, `z`, `set`, etc.) → handle internally
+7. Found in `$PATH` → execute directly (unless args look like prose → AI)
+8. Close to a known command → typo suggestion
+9. Everything else → AI translation
 
 ## Key Features
 
@@ -55,6 +58,7 @@ Every input is classified in order:
 | **History context** | AI sees your recent commands for follow-up queries |
 | **Syntax highlighting** | Full-line: commands, flags, strings, pipes, variables, comments |
 | **Tab completion** | git, cargo, docker, kubectl, make targets, paths, commands |
+| **Slash commands** | `/validate`, `/config`, `/model`, `/safety`, `/provider` — configure shako inline |
 | **Typo correction** | Levenshtein distance detection with `[Y/n]` prompt |
 | **Fish compatibility** | `set -x`, fish config import, conf.d, functions directory |
 | **Starship prompt** | Native integration with parallel left/right rendering |
@@ -69,6 +73,7 @@ Every input is classified in order:
 | [Shell Features](docs/shell-features.md) | Builtins, pipes, redirects, job control, functions, history |
 | [Smart Defaults](docs/smart-defaults.md) | Tool detection, auto-aliases, AI tool preferences |
 | [Configuration](docs/configuration.md) | Full config reference, LLM providers, behavior settings |
+| [Slash Commands](docs/slash-commands.md) | `/validate`, `/config`, `/model`, `/safety`, `/provider`, `/help` |
 | [ROADMAP](ROADMAP.md) | Planned features and architecture improvements |
 | [SCOPE](SCOPE.md) | Original design document |
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,92 @@
+# Slash Commands
+
+Slash commands are shako meta-commands for inspecting and configuring the shell
+at runtime. They use a `/name [args]` syntax and are classified before builtins
+or `$PATH` lookup, so they never conflict with external programs.
+
+Absolute filesystem paths (e.g. `/usr/bin/ls`) are **not** affected — only
+single alphabetic words after `/` are treated as slash commands.
+
+## Available Commands
+
+| Command | Description |
+|---|---|
+| `/help` | List all available slash commands |
+| `/validate` | Validate the AI endpoint (connectivity, auth, model) |
+| `/config` | Show the full current configuration |
+| `/model` | Show the active AI model and provider |
+| `/safety [mode]` | Show or change the safety mode for this session |
+| `/provider [name]` | Show or switch the active LLM provider for this session |
+
+## Usage Examples
+
+```
+$ /help                   # list all slash commands
+$ /validate               # check AI endpoint health
+$ /config                 # dump current config to terminal
+$ /model                  # show active model
+$ /safety                 # show current safety mode
+$ /safety off             # disable safety checks (session only)
+$ /safety warn            # re-enable safety warnings
+$ /provider lm_studio     # switch to the lm_studio provider
+$ /provider               # show available providers
+```
+
+## Details
+
+### `/validate`
+
+Probes the configured LLM endpoint by hitting `GET /v1/models` with a
+3-second timeout. Reports:
+
+- Endpoint URL and model name
+- Whether the API key environment variable is set
+- Connection status: **ready**, **auth failed**, **unreachable**, or **disabled**
+
+### `/safety [mode]`
+
+Controls how shako handles dangerous AI-generated commands (`rm -rf`,
+`sudo`, `chmod`, etc.):
+
+| Mode | Behavior |
+|---|---|
+| `warn` | Show a warning, still allow execution (default) |
+| `block` | Refuse to execute dangerous commands |
+| `off` | No safety checks |
+
+Changes are **session-only** — they revert when you exit. Edit
+`~/.config/shako/config.toml` to change the default.
+
+### `/provider [name]`
+
+Switch between named LLM providers defined in your config:
+
+```toml
+# ~/.config/shako/config.toml
+active_provider = "work_proxy"
+
+[providers.lm_studio]
+endpoint = "http://localhost:1234"
+model = "llama3"
+
+[providers.work_proxy]
+endpoint = "https://llm-proxy.corp.example.com"
+model = "claude-haiku-4.5"
+api_key_env = "LLMPROXY_KEY"
+```
+
+```
+$ /provider lm_studio     # switch to local model
+$ /provider work_proxy    # switch back to work proxy
+```
+
+Changes are **session-only**.
+
+## Adding New Slash Commands
+
+Slash commands are defined in `src/slash.rs`. To add a new one:
+
+1. Add a `(name, description)` entry to `SLASH_COMMANDS`
+2. Add a match arm in the `run()` function
+3. Implement the handler function
+4. Add tests

--- a/src/ai/client.rs
+++ b/src/ai/client.rs
@@ -122,7 +122,9 @@ pub async fn query_llm(
                 if !response.status().is_success() {
                     let status = response.status();
                     let body = response.text().await.unwrap_or_default();
-                    return Err(anyhow::anyhow!("LLM API {endpoint} returned {status}: {body}"));
+                    return Err(anyhow::anyhow!(
+                        "LLM API {endpoint} returned {status}: {body}"
+                    ));
                 }
 
                 // Collect raw bytes while streaming SSE tokens to stdout
@@ -174,8 +176,9 @@ pub async fn query_llm(
                 // Fallback: server returned plain JSON instead of SSE
                 log::debug!("stream yielded no content, falling back to non-streaming parse");
                 let body = String::from_utf8_lossy(&raw_bytes);
-                let chat_response: ChatResponse = serde_json::from_str(&body)
-                    .map_err(|e| anyhow::anyhow!("failed to parse LLM response: {e}\nbody: {body}"))?;
+                let chat_response: ChatResponse = serde_json::from_str(&body).map_err(|e| {
+                    anyhow::anyhow!("failed to parse LLM response: {e}\nbody: {body}")
+                })?;
                 return chat_response
                     .choices
                     .first()
@@ -211,7 +214,10 @@ pub enum AiCheckResult {
 
 /// Probe the configured LLM endpoint at startup and return its status.
 /// Hits `GET /v1/models` with a 3-second timeout — fast enough not to stall startup.
-pub async fn check_ai_session(config: &crate::config::LlmConfig, ai_enabled: bool) -> AiCheckResult {
+pub async fn check_ai_session(
+    config: &crate::config::LlmConfig,
+    ai_enabled: bool,
+) -> AiCheckResult {
     if !ai_enabled {
         return AiCheckResult::Disabled;
     }

--- a/src/ai/confirm.rs
+++ b/src/ai/confirm.rs
@@ -47,12 +47,13 @@ pub fn print_multi_command_preview(command: &str) -> bool {
     // Split on common chain operators and newlines (simple, not quote-aware)
     let mut steps: Vec<&str> = vec![command];
     for sep in [" && ", " || ", " ; ", "\n"] {
-        steps = steps
-            .into_iter()
-            .flat_map(|s| s.split(sep))
-            .collect();
+        steps = steps.into_iter().flat_map(|s| s.split(sep)).collect();
     }
-    let steps: Vec<&str> = steps.iter().map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+    let steps: Vec<&str> = steps
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
 
     if steps.len() < 2 {
         return false;

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -78,7 +78,10 @@ const TOOL_PREFERENCES: &[(&str, &str)] = &[
 ];
 
 /// Build context from the current environment.
-pub fn build_context(recent_history: Vec<String>, session_memory: Vec<(String, String)>) -> Result<ShellContext> {
+pub fn build_context(
+    recent_history: Vec<String>,
+    session_memory: Vec<(String, String)>,
+) -> Result<ShellContext> {
     let cwd = env::current_dir()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "unknown".to_string());

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -24,7 +24,8 @@ pub async fn translate_and_execute(
     let mut current_input = input.to_string();
 
     'translate: loop {
-        let response = client::query_llm(&system_prompt, &current_input, config.active_llm()).await?;
+        let response =
+            client::query_llm(&system_prompt, &current_input, config.active_llm()).await?;
         let command = collapse_multiline(response.trim());
 
         if command == "SHAKO_CANNOT_TRANSLATE" || command.is_empty() {
@@ -182,10 +183,7 @@ fn collapse_multiline(raw: &str) -> String {
 }
 
 /// Explain what a command does without executing it.
-pub async fn explain_command(
-    command: &str,
-    config: &ShakoConfig,
-) -> Result<String> {
+pub async fn explain_command(command: &str, config: &ShakoConfig) -> Result<String> {
     let ctx = context::build_context(vec![], vec![])?;
     let system_prompt = prompt::explain_prompt(&ctx);
 
@@ -193,7 +191,11 @@ pub async fn explain_command(
 }
 
 /// Search shell history using AI semantic matching.
-pub async fn search_history(query: &str, history: &[String], config: &ShakoConfig) -> Result<String> {
+pub async fn search_history(
+    query: &str,
+    history: &[String],
+    config: &ShakoConfig,
+) -> Result<String> {
     if history.is_empty() {
         return Ok("No history available.".to_string());
     }
@@ -205,7 +207,8 @@ pub async fn search_history(query: &str, history: &[String], config: &ShakoConfi
         .join("\n");
 
     let system = "You are a shell history search assistant. Given a list of shell commands and a search query, find the most relevant commands. Return just the matching commands, one per line, most relevant first. If nothing matches well, say so briefly.";
-    let user_msg = format!("Search query: {query}\n\nShell history (most recent last):\n{history_text}");
+    let user_msg =
+        format!("Search query: {query}\n\nShell history (most recent last):\n{history_text}");
 
     client::query_llm(system, &user_msg, config.active_llm()).await
 }

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -43,11 +43,16 @@ Rules:
     }
 
     if !ctx.project_context.is_empty() {
-        prompt.push_str(&format!("\n\nProject instructions:\n{}", ctx.project_context));
+        prompt.push_str(&format!(
+            "\n\nProject instructions:\n{}",
+            ctx.project_context
+        ));
     }
 
     if !ctx.session_memory.is_empty() {
-        prompt.push_str("\n\nRecent AI conversation context (use this to understand follow-up queries):\n");
+        prompt.push_str(
+            "\n\nRecent AI conversation context (use this to understand follow-up queries):\n",
+        );
         for (user_input, ai_cmd) in &ctx.session_memory {
             prompt.push_str(&format!("  User: {user_input}\n  Command: {ai_cmd}\n"));
         }
@@ -115,7 +120,10 @@ Rules:
     }
 
     if !ctx.project_context.is_empty() {
-        prompt.push_str(&format!("\n\nProject instructions:\n{}", ctx.project_context));
+        prompt.push_str(&format!(
+            "\n\nProject instructions:\n{}",
+            ctx.project_context
+        ));
     }
 
     if !ctx.recent_history.is_empty() {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -79,25 +79,70 @@ pub fn run_builtin(input: &str, state: &mut ShellState) -> i32 {
 
     match parts[0] {
         "cd" => builtin_cd(&parts[1..]),
-        "z" => { builtin_z(&parts[1..]); 0 }
-        "zi" => { builtin_zi(); 0 }
+        "z" => {
+            builtin_z(&parts[1..]);
+            0
+        }
+        "zi" => {
+            builtin_zi();
+            0
+        }
         "exit" => std::process::exit(0),
-        "export" => { builtin_export(&parts[1..]); 0 }
-        "unset" => { builtin_unset(&parts[1..]); 0 }
-        "set" => { set::builtin_set(&parts[1..]); 0 }
-        "history" => { builtin_history(&parts[1..], state); 0 }
-        "alias" => { builtin_alias(&parts[1..], state); 0 }
-        "unalias" => { builtin_unalias(&parts[1..], state); 0 }
-        "abbr" => { builtin_abbr(&parts[1..], state); 0 }
-        "fish-import" => { crate::fish_import::run_import(); 0 }
-        "source" => { source::builtin_source(&parts[1..], state); 0 }
+        "export" => {
+            builtin_export(&parts[1..]);
+            0
+        }
+        "unset" => {
+            builtin_unset(&parts[1..]);
+            0
+        }
+        "set" => {
+            set::builtin_set(&parts[1..]);
+            0
+        }
+        "history" => {
+            builtin_history(&parts[1..], state);
+            0
+        }
+        "alias" => {
+            builtin_alias(&parts[1..], state);
+            0
+        }
+        "unalias" => {
+            builtin_unalias(&parts[1..], state);
+            0
+        }
+        "abbr" => {
+            builtin_abbr(&parts[1..], state);
+            0
+        }
+        "fish-import" => {
+            crate::fish_import::run_import();
+            0
+        }
+        "source" => {
+            source::builtin_source(&parts[1..], state);
+            0
+        }
         "type" => builtin_type(&parts[1..], state),
-        "jobs" => { jobs::builtin_jobs(state); 0 }
-        "fg" => { jobs::builtin_fg(&parts[1..], state); 0 }
-        "bg" => { jobs::builtin_bg(&parts[1..], state); 0 }
+        "jobs" => {
+            jobs::builtin_jobs(state);
+            0
+        }
+        "fg" => {
+            jobs::builtin_fg(&parts[1..], state);
+            0
+        }
+        "bg" => {
+            jobs::builtin_bg(&parts[1..], state);
+            0
+        }
         "disown" => jobs::builtin_disown(&parts[1..], state),
         "wait" => jobs::builtin_wait(&parts[1..], state),
-        "functions" => { builtin_functions(state); 0 }
+        "functions" => {
+            builtin_functions(state);
+            0
+        }
         // Phase 2
         "echo" => builtin_echo(&parts[1..]),
         "read" => builtin_read(&parts[1..]),
@@ -106,14 +151,23 @@ pub fn run_builtin(input: &str, state: &mut ShellState) -> i32 {
             let args: Vec<&str> = parts[1..].iter().copied().filter(|a| *a != "]").collect();
             builtin_test(&args)
         }
-        "pwd" => { println!("{}", std::env::current_dir().unwrap_or_default().display()); 0 }
+        "pwd" => {
+            println!("{}", std::env::current_dir().unwrap_or_default().display());
+            0
+        }
         "pushd" => builtin_pushd(&parts[1..], state),
         "popd" => builtin_popd(&parts[1..], state),
-        "dirs" => { builtin_dirs(state); 0 }
+        "dirs" => {
+            builtin_dirs(state);
+            0
+        }
         "true" => 0,
         "false" => 1,
         "return" => {
-            let code = parts.get(1).and_then(|n| n.parse::<i32>().ok()).unwrap_or(0);
+            let code = parts
+                .get(1)
+                .and_then(|n| n.parse::<i32>().ok())
+                .unwrap_or(0);
             FUNCTION_RETURN.with(|r| r.set(Some(code)));
             code
         }
@@ -137,7 +191,10 @@ pub fn run_builtin(input: &str, state: &mut ShellState) -> i32 {
                 .and_then(|s| s.code())
                 .unwrap_or(0)
         }
-        other => { eprintln!("shako: unknown builtin: {other}"); 1 }
+        other => {
+            eprintln!("shako: unknown builtin: {other}");
+            1
+        }
     }
 }
 
@@ -258,18 +315,30 @@ fn run_builtin_no_state(first: &str, line: &str) -> i32 {
             let args: Vec<&str> = parts[1..].iter().copied().filter(|a| *a != "]").collect();
             builtin_test(&args)
         }
-        "pwd" => { println!("{}", std::env::current_dir().unwrap_or_default().display()); 0 }
+        "pwd" => {
+            println!("{}", std::env::current_dir().unwrap_or_default().display());
+            0
+        }
         "true" => 0,
         "false" => 1,
         "return" => {
-            let code = parts.get(1).and_then(|n| n.parse::<i32>().ok()).unwrap_or(0);
+            let code = parts
+                .get(1)
+                .and_then(|n| n.parse::<i32>().ok())
+                .unwrap_or(0);
             FUNCTION_RETURN.with(|r| r.set(Some(code)));
             code
         }
         "exit" => std::process::exit(0),
         "cd" => builtin_cd(&parts[1..]),
-        "export" => { builtin_export(&parts[1..]); 0 }
-        "unset" => { builtin_unset(&parts[1..]); 0 }
+        "export" => {
+            builtin_export(&parts[1..]);
+            0
+        }
+        "unset" => {
+            builtin_unset(&parts[1..]);
+            0
+        }
         "break" | "continue" => {
             eprintln!("shako: {first}: only meaningful inside a loop");
             1
@@ -584,15 +653,29 @@ fn builtin_echo(args: &[&str]) -> i32 {
 
     for (i, arg) in args.iter().enumerate() {
         match *arg {
-            "-n" => { newline = false; arg_start = i + 1; }
-            "-e" => { interpret = true; arg_start = i + 1; }
-            "-ne" | "-en" => { newline = false; interpret = true; arg_start = i + 1; }
+            "-n" => {
+                newline = false;
+                arg_start = i + 1;
+            }
+            "-e" => {
+                interpret = true;
+                arg_start = i + 1;
+            }
+            "-ne" | "-en" => {
+                newline = false;
+                interpret = true;
+                arg_start = i + 1;
+            }
             _ => break,
         }
     }
 
     let output = args[arg_start..].join(" ");
-    let output = if interpret { unescape_echo(&output) } else { output };
+    let output = if interpret {
+        unescape_echo(&output)
+    } else {
+        output
+    };
 
     if newline {
         println!("{output}");
@@ -617,7 +700,10 @@ fn unescape_echo(s: &str) -> String {
                 Some('b') => result.push('\x08'),
                 Some('\\') => result.push('\\'),
                 Some('0') => result.push('\0'),
-                Some(other) => { result.push('\\'); result.push(other); }
+                Some(other) => {
+                    result.push('\\');
+                    result.push(other);
+                }
                 None => result.push('\\'),
             }
         } else {
@@ -640,10 +726,14 @@ fn builtin_read(args: &[&str]) -> i32 {
         match args[i] {
             "-p" => {
                 i += 1;
-                if i < args.len() { prompt = args[i]; }
+                if i < args.len() {
+                    prompt = args[i];
+                }
             }
             "-r" => {}
-            arg if !arg.starts_with('-') => { var_name = arg; }
+            arg if !arg.starts_with('-') => {
+                var_name = arg;
+            }
             _ => {}
         }
         i += 1;
@@ -659,7 +749,10 @@ fn builtin_read(args: &[&str]) -> i32 {
     match std::io::stdin().read_line(&mut line) {
         Ok(0) => return 1,
         Ok(_) => {}
-        Err(e) => { eprintln!("shako: read: {e}"); return 1; }
+        Err(e) => {
+            eprintln!("shako: read: {e}");
+            return 1;
+        }
     }
 
     let value = line.trim_end_matches('\n').trim_end_matches('\r');
@@ -699,18 +792,27 @@ fn test_unary(op: &str, operand: &str) -> bool {
         "-d" => path.is_dir(),
         "-r" => {
             use std::os::unix::fs::PermissionsExt;
-            path.metadata().map(|m| m.permissions().mode() & 0o444 != 0).unwrap_or(false)
+            path.metadata()
+                .map(|m| m.permissions().mode() & 0o444 != 0)
+                .unwrap_or(false)
         }
         "-w" => {
             use std::os::unix::fs::PermissionsExt;
-            path.metadata().map(|m| m.permissions().mode() & 0o222 != 0).unwrap_or(false)
+            path.metadata()
+                .map(|m| m.permissions().mode() & 0o222 != 0)
+                .unwrap_or(false)
         }
         "-x" => {
             use std::os::unix::fs::PermissionsExt;
-            path.metadata().map(|m| m.permissions().mode() & 0o111 != 0).unwrap_or(false)
+            path.metadata()
+                .map(|m| m.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
         }
         "-s" => path.metadata().map(|m| m.len() > 0).unwrap_or(false),
-        "-L" | "-h" => path.symlink_metadata().map(|m| m.file_type().is_symlink()).unwrap_or(false),
+        "-L" | "-h" => path
+            .symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
         "-z" => operand.is_empty(),
         "-n" => !operand.is_empty(),
         _ => !op.is_empty(),
@@ -743,7 +845,10 @@ fn builtin_pushd(args: &[&str], state: &mut ShellState) -> i32 {
     }
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
-        Err(e) => { eprintln!("shako: pushd: {e}"); return 1; }
+        Err(e) => {
+            eprintln!("shako: pushd: {e}");
+            return 1;
+        }
     };
     let code = builtin_cd(args);
     if code == 0 {
@@ -759,10 +864,15 @@ fn builtin_popd(_args: &[&str], state: &mut ShellState) -> i32 {
         Some(dir) => {
             let dir_str = dir.display().to_string();
             let code = builtin_cd(&[dir_str.as_str()]);
-            if code == 0 { builtin_dirs(state); }
+            if code == 0 {
+                builtin_dirs(state);
+            }
             code
         }
-        None => { eprintln!("shako: popd: directory stack empty"); 1 }
+        None => {
+            eprintln!("shako: popd: directory stack empty");
+            1
+        }
     }
 }
 

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -105,7 +105,8 @@ pub fn source_fish_string(contents: &str, state: &mut ShellState) {
                     || inner.starts_with("begin ")
                 {
                     depth += 1;
-                } else if inner == "end" || inner.starts_with("end ") || inner.starts_with("end\t") {
+                } else if inner == "end" || inner.starts_with("end ") || inner.starts_with("end\t")
+                {
                     depth -= 1;
                     if depth == 0 {
                         i += 1;
@@ -118,9 +119,7 @@ pub fn source_fish_string(contents: &str, state: &mut ShellState) {
 
             let body = body_lines.join("; ");
             if !body.is_empty() {
-                state
-                    .functions
-                    .insert(name, ShellFunction { body });
+                state.functions.insert(name, ShellFunction { body });
             }
             continue;
         }
@@ -153,9 +152,8 @@ pub fn source_fish_string(contents: &str, state: &mut ShellState) {
         // export KEY=VALUE — expand command substitution and env vars
         if let Some(rest) = line.strip_prefix("export ") {
             if let Some((key, value)) = rest.split_once('=') {
-                let expanded = crate::parser::parse_args(
-                    value.trim_matches('\'').trim_matches('"'),
-                );
+                let expanded =
+                    crate::parser::parse_args(value.trim_matches('\'').trim_matches('"'));
                 let value = expanded.join(" ");
                 unsafe { std::env::set_var(key.trim(), &value) };
             }

--- a/src/builtins/state.rs
+++ b/src/builtins/state.rs
@@ -113,10 +113,8 @@ impl ShellState {
                 if let Ok(contents) = std::fs::read_to_string(&path) {
                     let body = super::source::parse_fish_function_file(&contents);
                     if !body.is_empty() {
-                        self.functions.insert(
-                            name.to_string(),
-                            ShellFunction { body },
-                        );
+                        self.functions
+                            .insert(name.to_string(), ShellFunction { body });
                         return true;
                     }
                 }

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -23,6 +23,8 @@ pub enum Classification {
     Typo { suggestion: String },
     /// Command ending with `?` — explain what it does without executing.
     ExplainCommand(String),
+    /// Slash command — internal shako meta-command (e.g. `/validate`, `/help`).
+    SlashCommand { name: String, args: String },
     /// Empty input.
     Empty,
 }
@@ -77,6 +79,23 @@ impl Classifier {
             let cmd = trimmed.trim_end_matches('?').trim();
             if !cmd.is_empty() {
                 return Classification::ExplainCommand(cmd.to_string());
+            }
+        }
+
+        // Slash commands: `/word` where word is alphabetic (not a filesystem path).
+        // e.g. `/validate`, `/help`, `/config` — but not `/usr/bin/ls`.
+        if let Some(rest) = trimmed.strip_prefix('/') {
+            let cmd_part = rest.split_whitespace().next().unwrap_or("");
+            if !cmd_part.is_empty()
+                && cmd_part
+                    .chars()
+                    .all(|c| c.is_ascii_alphabetic() || c == '-' || c == '_')
+            {
+                let args = rest[cmd_part.len()..].trim().to_string();
+                return Classification::SlashCommand {
+                    name: cmd_part.to_string(),
+                    args,
+                };
             }
         }
 
@@ -138,19 +157,17 @@ impl Classifier {
         // Check builtins
         for &builtin in BUILTINS {
             let dist = damerau_levenshtein(token, builtin);
-            if dist > 0 && dist <= 2
-                && best.as_ref().is_none_or(|(_, d)| dist < *d) {
-                    best = Some((builtin.to_string(), dist));
-                }
+            if dist > 0 && dist <= 2 && best.as_ref().is_none_or(|(_, d)| dist < *d) {
+                best = Some((builtin.to_string(), dist));
+            }
         }
 
         // Check PATH commands
         for cmd in &self.cache.commands {
             let dist = damerau_levenshtein(token, cmd);
-            if dist > 0 && dist <= 2
-                && best.as_ref().is_none_or(|(_, d)| dist < *d) {
-                    best = Some((cmd.clone(), dist));
-                }
+            if dist > 0 && dist <= 2 && best.as_ref().is_none_or(|(_, d)| dist < *d) {
+                best = Some((cmd.clone(), dist));
+            }
         }
 
         best.map(|(cmd, _)| cmd)
@@ -173,23 +190,82 @@ fn looks_like_natural_language(args: &[&str]) -> bool {
 
     // Common words that appear in English prose but never as shell arguments.
     const NL_WORDS: &[&str] = &[
-        "the", "a", "an", "all", "every", "each", "any", "some",
-        "in", "on", "at", "to", "for", "of", "by", "with", "from", "into",
-        "this", "that", "these", "those",
-        "my", "me", "i",
-        "file", "files", "directory", "folder", "folders",
-        "which", "what", "how", "where", "when",
-        "are", "is", "was", "were", "be", "been", "have", "has",
-        "over", "under", "above", "below", "than", "between",
-        "larger", "smaller", "bigger", "size", "sized",
-        "modified", "created", "changed", "named", "called",
-        "today", "yesterday", "recent", "latest",
-        "largest", "smallest", "biggest", "newest", "oldest",
+        "the",
+        "a",
+        "an",
+        "all",
+        "every",
+        "each",
+        "any",
+        "some",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "by",
+        "with",
+        "from",
+        "into",
+        "this",
+        "that",
+        "these",
+        "those",
+        "my",
+        "me",
+        "i",
+        "file",
+        "files",
+        "directory",
+        "folder",
+        "folders",
+        "which",
+        "what",
+        "how",
+        "where",
+        "when",
+        "are",
+        "is",
+        "was",
+        "were",
+        "be",
+        "been",
+        "have",
+        "has",
+        "over",
+        "under",
+        "above",
+        "below",
+        "than",
+        "between",
+        "larger",
+        "smaller",
+        "bigger",
+        "size",
+        "sized",
+        "modified",
+        "created",
+        "changed",
+        "named",
+        "called",
+        "today",
+        "yesterday",
+        "recent",
+        "latest",
+        "largest",
+        "smallest",
+        "biggest",
+        "newest",
+        "oldest",
     ];
 
     // NL words take priority: prose words in the args mean it's natural language
     // even if a path like ~/Documents is also present.
-    if args.iter().any(|a| NL_WORDS.iter().any(|w| a.eq_ignore_ascii_case(w))) {
+    if args
+        .iter()
+        .any(|a| NL_WORDS.iter().any(|w| a.eq_ignore_ascii_case(w)))
+    {
         return true;
     }
 
@@ -358,6 +434,63 @@ mod tests {
         assert!(
             matches!(result, Classification::NaturalLanguage(_)),
             "expected NaturalLanguage for 'list all files', got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_slash_command_basic() {
+        let c = test_classifier();
+        let result = c.classify("/help");
+        assert!(
+            matches!(result, Classification::SlashCommand { ref name, .. } if name == "help"),
+            "expected SlashCommand 'help', got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_slash_command_with_args() {
+        let c = test_classifier();
+        let result = c.classify("/safety warn");
+        match result {
+            Classification::SlashCommand { name, args } => {
+                assert_eq!(name, "safety");
+                assert_eq!(args, "warn");
+            }
+            other => panic!("expected SlashCommand, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_slash_command_with_hyphen() {
+        let c = test_classifier();
+        let result = c.classify("/my-command");
+        assert!(
+            matches!(result, Classification::SlashCommand { ref name, .. } if name == "my-command"),
+            "expected SlashCommand 'my-command', got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_absolute_path_not_slash_command() {
+        let c = test_classifier();
+        let result = c.classify("/usr/bin/ls");
+        assert!(
+            matches!(result, Classification::Command(_)),
+            "expected Command for absolute path, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_slash_root_not_slash_command() {
+        let c = test_classifier();
+        let result = c.classify("/bin/echo hello");
+        assert!(
+            matches!(result, Classification::Command(_)),
+            "expected Command for /bin/echo, got {:?}",
             result
         );
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,3 @@
 mod schema;
 
-pub use schema::{ShakoConfig, LlmConfig};
+pub use schema::{LlmConfig, ShakoConfig};

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct ShakoConfig {
     /// Legacy single-provider config. Used when no `active_provider` is set.
     #[serde(default)]

--- a/src/control.rs
+++ b/src/control.rs
@@ -108,15 +108,28 @@ fn split_semicolons(s: &str) -> Vec<String> {
             continue;
         }
         match c {
-            '\\' if !in_single => { prev_bs = true; current.push(c); }
-            '\'' if !in_double => { in_single = !in_single; current.push(c); }
-            '"' if !in_single => { in_double = !in_double; current.push(c); }
+            '\\' if !in_single => {
+                prev_bs = true;
+                current.push(c);
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+                current.push(c);
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                current.push(c);
+            }
             ';' if !in_single && !in_double => {
                 let t = current.trim().to_string();
-                if !t.is_empty() { result.push(t); }
+                if !t.is_empty() {
+                    result.push(t);
+                }
                 current.clear();
             }
-            _ => { current.push(c); }
+            _ => {
+                current.push(c);
+            }
         }
     }
     let tail = current.trim().to_string();
@@ -134,15 +147,15 @@ fn leading_keyword(seg: &str) -> Option<(Kw, &str)> {
         ("elif", Kw::Elif),
         ("else", Kw::Else),
         ("then", Kw::Then),
-        ("done", Kw::Done),   // bash compat alias for end
-        ("end", Kw::End),     // fish canonical block closer
+        ("done", Kw::Done), // bash compat alias for end
+        ("end", Kw::End),   // fish canonical block closer
         ("while", Kw::While),
         ("local", Kw::Local),
         ("continue", Kw::Continue),
         ("break", Kw::Break),
-        ("fi", Kw::Fi),       // bash compat alias for end
+        ("fi", Kw::Fi), // bash compat alias for end
         ("for", Kw::For),
-        ("do", Kw::Do),       // bash compat, optional in fish
+        ("do", Kw::Do), // bash compat, optional in fish
         ("if", Kw::If),
     ];
     for (kw_str, kw) in KWS {
@@ -163,7 +176,9 @@ fn leading_keyword(seg: &str) -> Option<(Kw, &str)> {
 /// in the remainder after each keyword is extracted.
 fn emit_segment(seg: &str, tokens: &mut Vec<BodyToken>) {
     let seg = seg.trim();
-    if seg.is_empty() { return; }
+    if seg.is_empty() {
+        return;
+    }
     if let Some((kw, rest)) = leading_keyword(seg) {
         tokens.push(BodyToken::Kw(kw));
         emit_segment(rest, tokens);
@@ -216,14 +231,22 @@ impl Parser {
 
     fn take_cmd(&mut self) -> String {
         match self.tokens.get(self.pos) {
-            Some(BodyToken::Cmd(c)) => { let s = c.clone(); self.pos += 1; s }
+            Some(BodyToken::Cmd(c)) => {
+                let s = c.clone();
+                self.pos += 1;
+                s
+            }
             _ => String::new(),
         }
     }
 
     fn take_kw(&mut self) -> Option<Kw> {
         match self.tokens.get(self.pos) {
-            Some(BodyToken::Kw(k)) => { let k = k.clone(); self.pos += 1; Some(k) }
+            Some(BodyToken::Kw(k)) => {
+                let k = k.clone();
+                self.pos += 1;
+                Some(k)
+            }
             _ => None,
         }
     }
@@ -282,12 +305,20 @@ impl Parser {
                             self.skip_end_kw(); // accept end / fi
                             break;
                         }
-                        Some(Kw::End) | Some(Kw::Fi) => { self.skip_end_kw(); break; }
+                        Some(Kw::End) | Some(Kw::Fi) => {
+                            self.skip_end_kw();
+                            break;
+                        }
                         _ => break,
                     }
                 }
 
-                Some(Statement::If { condition, then_body, elif_branches, else_body })
+                Some(Statement::If {
+                    condition,
+                    then_body,
+                    elif_branches,
+                    else_body,
+                })
             }
 
             BodyToken::Kw(Kw::For) => {
@@ -297,7 +328,11 @@ impl Parser {
                 self.skip_kw(&Kw::Do); // optional in fish syntax
                 let body = self.parse_until(&[Kw::End, Kw::Done]);
                 self.skip_end_kw(); // accept end / done
-                Some(Statement::For { var, items_expr, body })
+                Some(Statement::For {
+                    var,
+                    items_expr,
+                    body,
+                })
             }
 
             BodyToken::Kw(Kw::While) => {
@@ -309,16 +344,29 @@ impl Parser {
                 Some(Statement::While { condition, body })
             }
 
-            BodyToken::Kw(Kw::Break) => { self.pos += 1; Some(Statement::Break) }
-            BodyToken::Kw(Kw::Continue) => { self.pos += 1; Some(Statement::Continue) }
+            BodyToken::Kw(Kw::Break) => {
+                self.pos += 1;
+                Some(Statement::Break)
+            }
+            BodyToken::Kw(Kw::Continue) => {
+                self.pos += 1;
+                Some(Statement::Continue)
+            }
             BodyToken::Kw(Kw::Local) => {
                 self.pos += 1;
                 let spec = self.take_cmd();
-                if spec.is_empty() { None } else { Some(Statement::Local(spec)) }
+                if spec.is_empty() {
+                    None
+                } else {
+                    Some(Statement::Local(spec))
+                }
             }
 
             // Stray structural keywords at statement level — skip silently
-            BodyToken::Kw(_) => { self.take_kw(); None }
+            BodyToken::Kw(_) => {
+                self.take_kw();
+                None
+            }
 
             BodyToken::Cmd(cmd) => {
                 self.pos += 1;
@@ -326,7 +374,11 @@ impl Parser {
                 // didn't separate `local` from its argument in the original body.
                 if let Some(rest) = cmd.strip_prefix("local ") {
                     let rest = rest.trim().to_string();
-                    if rest.is_empty() { None } else { Some(Statement::Local(rest)) }
+                    if rest.is_empty() {
+                        None
+                    } else {
+                        Some(Statement::Local(rest))
+                    }
                 } else {
                     Some(Statement::Simple(cmd))
                 }
@@ -380,7 +432,12 @@ fn exec_one(stmt: &Statement, locals: &mut Vec<(String, Option<String>)>) -> Exe
     match stmt {
         Statement::Simple(cmd) => exec_simple(cmd, locals),
 
-        Statement::If { condition, then_body, elif_branches, else_body } => {
+        Statement::If {
+            condition,
+            then_body,
+            elif_branches,
+            else_body,
+        } => {
             if run_condition(condition) == 0 {
                 exec_statements(then_body, locals)
             } else {
@@ -393,7 +450,11 @@ fn exec_one(stmt: &Statement, locals: &mut Vec<(String, Option<String>)>) -> Exe
             }
         }
 
-        Statement::For { var, items_expr, body } => {
+        Statement::For {
+            var,
+            items_expr,
+            body,
+        } => {
             let items = crate::parser::parse_args(items_expr);
             let mut last = 0i32;
             'for_loop: for item in &items {
@@ -412,7 +473,9 @@ fn exec_one(stmt: &Statement, locals: &mut Vec<(String, Option<String>)>) -> Exe
         Statement::While { condition, body } => {
             let mut last = 0i32;
             'while_loop: loop {
-                if run_condition(condition) != 0 { break; }
+                if run_condition(condition) != 0 {
+                    break;
+                }
                 match exec_statements(body, locals) {
                     ExecSignal::Normal(c) => last = c,
                     ExecSignal::Continue => continue 'while_loop,
@@ -454,7 +517,9 @@ fn declare_local(var: &str, locals: &mut Vec<(String, Option<String>)>) {
 /// Execute a simple command, checking the FUNCTION_RETURN thread-local after.
 fn exec_simple(cmd: &str, _locals: &mut Vec<(String, Option<String>)>) -> ExecSignal {
     let cmd = cmd.trim();
-    if cmd.is_empty() { return ExecSignal::Normal(0); }
+    if cmd.is_empty() {
+        return ExecSignal::Normal(0);
+    }
 
     let first = cmd.split_whitespace().next().unwrap_or("");
     let code = if crate::builtins::is_builtin(first) {
@@ -476,7 +541,9 @@ fn exec_simple(cmd: &str, _locals: &mut Vec<(String, Option<String>)>) -> ExecSi
 /// Run a condition and return its exit code.
 fn run_condition(condition: &str) -> i32 {
     let condition = condition.trim();
-    if condition.is_empty() { return 0; }
+    if condition.is_empty() {
+        return 0;
+    }
 
     let first = condition.split_whitespace().next().unwrap_or("");
     if crate::builtins::is_builtin(first) {
@@ -560,7 +627,13 @@ mod tests {
     fn test_parse_body_if_simple() {
         let stmts = parse_body("if true; then echo yes; fi");
         assert_eq!(stmts.len(), 1);
-        let Statement::If { condition, then_body, else_body, elif_branches } = &stmts[0] else {
+        let Statement::If {
+            condition,
+            then_body,
+            else_body,
+            elif_branches,
+        } = &stmts[0]
+        else {
             panic!("expected If");
         };
         assert_eq!(condition, "true");
@@ -573,7 +646,14 @@ mod tests {
     fn test_parse_body_if_else() {
         let stmts = parse_body("if false; then echo yes; else echo no; fi");
         assert_eq!(stmts.len(), 1);
-        let Statement::If { then_body, else_body, .. } = &stmts[0] else { panic!() };
+        let Statement::If {
+            then_body,
+            else_body,
+            ..
+        } = &stmts[0]
+        else {
+            panic!()
+        };
         assert_eq!(then_body.len(), 1);
         assert_eq!(else_body.len(), 1);
     }
@@ -581,7 +661,14 @@ mod tests {
     #[test]
     fn test_parse_body_if_elif_else() {
         let stmts = parse_body("if false; then echo a; elif true; then echo b; else echo c; fi");
-        let Statement::If { elif_branches, else_body, .. } = &stmts[0] else { panic!() };
+        let Statement::If {
+            elif_branches,
+            else_body,
+            ..
+        } = &stmts[0]
+        else {
+            panic!()
+        };
         assert_eq!(elif_branches.len(), 1);
         assert_eq!(else_body.len(), 1);
     }
@@ -590,7 +677,14 @@ mod tests {
     fn test_parse_body_for() {
         let stmts = parse_body("for i in 1 2 3; do echo $i; done");
         assert_eq!(stmts.len(), 1);
-        let Statement::For { var, items_expr, body } = &stmts[0] else { panic!() };
+        let Statement::For {
+            var,
+            items_expr,
+            body,
+        } = &stmts[0]
+        else {
+            panic!()
+        };
         assert_eq!(var, "i");
         assert_eq!(items_expr, "1 2 3");
         assert_eq!(body.len(), 1);
@@ -600,28 +694,36 @@ mod tests {
     fn test_parse_body_while() {
         let stmts = parse_body("while false; do echo hi; done");
         assert_eq!(stmts.len(), 1);
-        let Statement::While { condition, .. } = &stmts[0] else { panic!() };
+        let Statement::While { condition, .. } = &stmts[0] else {
+            panic!()
+        };
         assert_eq!(condition, "false");
     }
 
     #[test]
     fn test_parse_body_break_in_for() {
         let stmts = parse_body("for i in 1; do break; done");
-        let Statement::For { body, .. } = &stmts[0] else { panic!() };
+        let Statement::For { body, .. } = &stmts[0] else {
+            panic!()
+        };
         assert!(matches!(body[0], Statement::Break));
     }
 
     #[test]
     fn test_parse_body_continue_in_for() {
         let stmts = parse_body("for i in 1 2; do continue; echo skip; done");
-        let Statement::For { body, .. } = &stmts[0] else { panic!() };
+        let Statement::For { body, .. } = &stmts[0] else {
+            panic!()
+        };
         assert!(matches!(body[0], Statement::Continue));
     }
 
     #[test]
     fn test_parse_body_nested_if() {
         let stmts = parse_body("if true; then if true; then echo deep; fi; fi");
-        let Statement::If { then_body, .. } = &stmts[0] else { panic!() };
+        let Statement::If { then_body, .. } = &stmts[0] else {
+            panic!()
+        };
         assert!(matches!(then_body[0], Statement::If { .. }));
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -269,7 +269,9 @@ pub fn execute_command_with_stderr(input: &str) -> (Option<ExitStatus>, String) 
 
     if let Some(ref path) = redir.stdin_path {
         match File::open(path) {
-            Ok(f) => { cmd.stdin(Stdio::from(f)); }
+            Ok(f) => {
+                cmd.stdin(Stdio::from(f));
+            }
             Err(e) => {
                 eprintln!("shako: {path}: {e}");
                 return (Some(fake_status(1)), String::new());
@@ -284,7 +286,9 @@ pub fn execute_command_with_stderr(input: &str) -> (Option<ExitStatus>, String) 
             File::create(path)
         };
         match file {
-            Ok(f) => { cmd.stdout(Stdio::from(f)); }
+            Ok(f) => {
+                cmd.stdout(Stdio::from(f));
+            }
             Err(e) => {
                 eprintln!("shako: {path}: {e}");
                 return (Some(fake_status(1)), String::new());
@@ -553,10 +557,7 @@ fn execute_pipeline(segments: &[String]) -> ExitStatus {
     let shell_pgid = nix::unistd::getpgrp();
     #[cfg(unix)]
     if pipeline_pgid != 0 {
-        let _ = nix::unistd::tcsetpgrp(
-            std::io::stdin(),
-            nix::unistd::Pid::from_raw(pipeline_pgid),
-        );
+        let _ = nix::unistd::tcsetpgrp(std::io::stdin(), nix::unistd::Pid::from_raw(pipeline_pgid));
     }
 
     let mut last_status = fake_status(0);
@@ -621,7 +622,6 @@ fn parse_redirects(input: &str) -> Redirects {
 
     while i < tokens.len() {
         match tokens[i] {
-
             "2>&1" => {
                 stderr_to_stdout = true;
                 i += 1;
@@ -764,11 +764,20 @@ fn strip_herestring_from_input(input: &str) -> String {
 
     while i < chars.len() {
         match chars[i] {
-            '\'' if !in_double => { in_single = !in_single; i += 1; }
-            '"'  if !in_single => { in_double = !in_double; i += 1; }
-            '<' if !in_single && !in_double
+            '\'' if !in_double => {
+                in_single = !in_single;
+                i += 1;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                i += 1;
+            }
+            '<' if !in_single
+                && !in_double
                 && i + 2 < chars.len()
-                && chars[i + 1] == '<' && chars[i + 2] == '<' => {
+                && chars[i + 1] == '<'
+                && chars[i + 2] == '<' =>
+            {
                 let start = i;
                 i += 3; // skip <<<
                 // Skip whitespace between <<< and the word
@@ -781,7 +790,7 @@ fn strip_herestring_from_input(input: &str) -> String {
                 while i < chars.len() {
                     match chars[i] {
                         '\'' if !wd => ws = !ws,
-                        '"'  if !ws => wd = !wd,
+                        '"' if !ws => wd = !wd,
                         ' ' | '\t' if !ws && !wd => break,
                         _ => {}
                     }
@@ -791,7 +800,9 @@ fn strip_herestring_from_input(input: &str) -> String {
                 let after: String = chars[i..].iter().collect();
                 return format!("{}{}", before.trim_end(), after);
             }
-            _ => { i += 1; }
+            _ => {
+                i += 1;
+            }
         }
     }
     input.to_string()
@@ -801,7 +812,10 @@ fn strip_herestring_from_input(input: &str) -> String {
 /// Tries `sh -c "exit N"` first; falls back to `/bin/true` or `/bin/false`
 /// in restricted environments where `sh` is unavailable (containers, sandboxes).
 fn fake_status(code: i32) -> ExitStatus {
-    if let Ok(s) = Command::new("sh").args(["-c", &format!("exit {code}")]).status() {
+    if let Ok(s) = Command::new("sh")
+        .args(["-c", &format!("exit {code}")])
+        .status()
+    {
         return s;
     }
     let fallback = if code == 0 { "/bin/true" } else { "/bin/false" };

--- a/src/fish_import.rs
+++ b/src/fish_import.rs
@@ -39,23 +39,9 @@ pub fn run_import() {
         .unwrap_or_else(|| home.join(".config"))
         .join("shako");
 
-    writeln!(
-        out,
-        "\x1b[1;36m fish → shako config import\x1b[0m\n"
-    )
-    .ok();
-    writeln!(
-        out,
-        " \x1b[90mfrom:\x1b[0m {}",
-        fish_dir.display()
-    )
-    .ok();
-    writeln!(
-        out,
-        " \x1b[90m  to:\x1b[0m {}\n",
-        shako_dir.display()
-    )
-    .ok();
+    writeln!(out, "\x1b[1;36m fish → shako config import\x1b[0m\n").ok();
+    writeln!(out, " \x1b[90mfrom:\x1b[0m {}", fish_dir.display()).ok();
+    writeln!(out, " \x1b[90m  to:\x1b[0m {}\n", shako_dir.display()).ok();
 
     fs::create_dir_all(shako_dir.join("conf.d")).ok();
     fs::create_dir_all(shako_dir.join("functions")).ok();
@@ -80,11 +66,7 @@ pub fn run_import() {
                 } else {
                     fs::write(&dest, &converted).ok();
                 }
-                writeln!(
-                    out,
-                    " \x1b[32m✓\x1b[0m config.fish → config.shako"
-                )
-                .ok();
+                writeln!(out, " \x1b[32m✓\x1b[0m config.fish → config.shako").ok();
             }
             Err(e) => {
                 writeln!(out, " \x1b[31m✗\x1b[0m config.fish: {e}").ok();
@@ -99,11 +81,7 @@ pub fn run_import() {
             .into_iter()
             .flatten()
             .flatten()
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .ends_with(".fish")
-            })
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".fish"))
             .collect();
         files.sort_by_key(|e| e.file_name());
 
@@ -118,11 +96,7 @@ pub fn run_import() {
                     let converted = convert_fish_config(&contents, &mut stats);
                     if !converted.trim().is_empty() {
                         fs::write(&dest, &converted).ok();
-                        writeln!(
-                            out,
-                            " \x1b[32m✓\x1b[0m conf.d/{name} → conf.d/{dest_name}"
-                        )
-                        .ok();
+                        writeln!(out, " \x1b[32m✓\x1b[0m conf.d/{name} → conf.d/{dest_name}").ok();
                     } else {
                         writeln!(
                             out,
@@ -270,9 +244,7 @@ fn convert_fish_config(contents: &str, stats: &mut ImportStats) -> String {
             || line.starts_with("while ")
         {
             // Extract useful content from `if status is-interactive` blocks
-            if line.contains("status is-interactive")
-                || line.contains("status --is-interactive")
-            {
+            if line.contains("status is-interactive") || line.contains("status --is-interactive") {
                 let mut depth = 1;
                 while i < lines.len() && depth > 0 {
                     let inner = lines[i].trim();
@@ -286,8 +258,7 @@ fn convert_fish_config(contents: &str, stats: &mut ImportStats) -> String {
                         depth -= 1;
                     } else if depth == 1 && inner != "else" && !inner.starts_with("else if") {
                         // Recursively process lines inside the interactive block
-                        let inner_result =
-                            convert_fish_config(&format!("{inner}\n"), stats);
+                        let inner_result = convert_fish_config(&format!("{inner}\n"), stats);
                         let inner_result = inner_result.trim();
                         if !inner_result.is_empty() {
                             output.push(inner_result.to_string());
@@ -505,10 +476,7 @@ fn convert_set_line(line: &str, seen: &mut HashMap<String, bool>) -> Option<Stri
                 .iter()
                 .filter(|p| {
                     // Skip default system paths and fish internals
-                    !matches!(
-                        **p,
-                        "/usr/bin" | "/bin" | "/usr/sbin" | "/sbin" | "$PATH"
-                    )
+                    !matches!(**p, "/usr/bin" | "/bin" | "/usr/sbin" | "/sbin" | "$PATH")
                 })
                 .map(|p| format!("fish_add_path {p}"))
                 .collect();
@@ -676,9 +644,23 @@ fn is_fish_internal_function(name: &str) -> bool {
         || name.starts_with("__")
         || matches!(
             name,
-            "cd" | "ls" | "ll" | "la" | "help" | "man" | "open"
-                | "N" | "Y" | "alias" | "history" | "type"
-                | "isatty" | "realpath" | "suspend" | "trap" | "umask"
-                | "vared" | "wait"
+            "cd" | "ls"
+                | "ll"
+                | "la"
+                | "help"
+                | "man"
+                | "open"
+                | "N"
+                | "Y"
+                | "alias"
+                | "history"
+                | "type"
+                | "isatty"
+                | "realpath"
+                | "suspend"
+                | "trap"
+                | "umask"
+                | "vared"
+                | "wait"
         )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod proactive;
 mod safety;
 mod setup;
 mod shell;
+mod slash;
 mod smart_defaults;
 
 use builtins::ShellState;
@@ -32,7 +33,9 @@ fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let quiet = args.iter().any(|a| a == "--quiet" || a == "-q");
     let init = args.iter().any(|a| a == "--init");
-    let cmd_mode = args.iter().position(|a| a == "-c")
+    let cmd_mode = args
+        .iter()
+        .position(|a| a == "-c")
         .map(|i| args.get(i + 1).cloned().unwrap_or_default());
 
     env_logger::init();
@@ -110,7 +113,7 @@ fn main() -> Result<()> {
         std::process::exit(last_code);
     }
 
-    let (config, first_run) = ShakoConfig::load()?;
+    let (mut config, first_run) = ShakoConfig::load()?;
     let rt = tokio::runtime::Runtime::new()?;
 
     if !quiet {
@@ -132,7 +135,10 @@ fn main() -> Result<()> {
     let highlighter = shell::highlighter::ShakoHighlighter::new(path_cache.clone());
     let extra_completions: std::sync::Arc<std::sync::RwLock<Vec<String>>> =
         std::sync::Arc::new(std::sync::RwLock::new(vec![]));
-    let completer = shell::completer::ShakoCompleter::new(path_cache, std::sync::Arc::clone(&extra_completions));
+    let completer = shell::completer::ShakoCompleter::new(
+        path_cache,
+        std::sync::Arc::clone(&extra_completions),
+    );
     let hinter = shell::hinter::create_hinter();
 
     let history_path = dirs::data_dir()
@@ -163,13 +169,25 @@ fn main() -> Result<()> {
     let edit_mode: Box<dyn EditMode> = if config.behavior.edit_mode == "vi" {
         // Add Tab completion to vi insert mode — Vi::default() has no completion binding.
         let mut insert_kb = default_vi_insert_keybindings();
-        insert_kb.add_binding(KeyModifiers::NONE, KeyCode::Tab, tab_completion_binding.clone());
-        insert_kb.add_binding(KeyModifiers::SHIFT, KeyCode::BackTab, ReedlineEvent::MenuPrevious);
+        insert_kb.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Tab,
+            tab_completion_binding.clone(),
+        );
+        insert_kb.add_binding(
+            KeyModifiers::SHIFT,
+            KeyCode::BackTab,
+            ReedlineEvent::MenuPrevious,
+        );
         Box::new(Vi::new(insert_kb, default_vi_normal_keybindings()))
     } else {
         let mut keybindings = default_emacs_keybindings();
         keybindings.add_binding(KeyModifiers::NONE, KeyCode::Tab, tab_completion_binding);
-        keybindings.add_binding(KeyModifiers::SHIFT, KeyCode::BackTab, ReedlineEvent::MenuPrevious);
+        keybindings.add_binding(
+            KeyModifiers::SHIFT,
+            KeyCode::BackTab,
+            ReedlineEvent::MenuPrevious,
+        );
         Box::new(Emacs::new(keybindings))
     };
 
@@ -272,8 +290,7 @@ fn main() -> Result<()> {
 
     // 4. Source fish config if enabled (reuse existing fish setup)
     if config.fish.source_config {
-        let fish_config_dir = dirs::home_dir()
-            .map(|h| h.join(".config").join("fish"));
+        let fish_config_dir = dirs::home_dir().map(|h| h.join(".config").join("fish"));
 
         if let Some(ref fish_dir) = fish_config_dir {
             // Fish conf.d/ snippets first
@@ -428,20 +445,19 @@ fn main() -> Result<()> {
                 match classifier.classify(&input) {
                     Classification::Command(cmd) => {
                         ran_foreground = true;
-                        let (status, stderr_output) =
-                            executor::execute_command_with_stderr(&cmd);
+                        let (status, stderr_output) = executor::execute_command_with_stderr(&cmd);
                         set_exit_code(status);
                         if let Some(s) = status {
                             if !s.success() {
                                 if config.behavior.ai_enabled {
-                                offer_ai_recovery(
-                                    &cmd,
-                                    s.code().unwrap_or(1),
-                                    &stderr_output,
-                                    &config,
-                                    &rt,
-                                    &history_path,
-                                );
+                                    offer_ai_recovery(
+                                        &cmd,
+                                        s.code().unwrap_or(1),
+                                        &stderr_output,
+                                        &config,
+                                        &rt,
+                                        &history_path,
+                                    );
                                 }
                             } else if config.behavior.ai_enabled {
                                 proactive::check(&cmd, &config, &rt);
@@ -468,7 +484,9 @@ fn main() -> Result<()> {
                                 parser::ChainOp::Or => last_code == 0,
                                 _ => false,
                             };
-                            if stop { break; }
+                            if stop {
+                                break;
+                            }
                         }
                         prompt::set_last_status(last_code);
                     }
@@ -476,45 +494,16 @@ fn main() -> Result<()> {
                         if !config.behavior.ai_enabled {
                             eprintln!("shako: AI is disabled (ai_enabled = false in config)");
                         } else {
-                        let history = read_recent_history(&history_path, config.behavior.history_context_lines);
-                        match rt.block_on(ai::translate_and_execute(&text, &config, history, &mut state.ai_session_memory)) {
-                            Ok(_) => prompt::set_last_status(0),
-                            Err(e) => {
-                                eprintln!("shako: ai error: {e}");
-                                prompt::set_last_status(1);
-                            }
-                        }
-                        }
-                    }
-                    Classification::ForcedAI(text) => {
-                        if !config.behavior.ai_enabled {
-                            eprintln!("shako: AI is disabled (ai_enabled = false in config)");
-                        } else {
-                        let words: Vec<&str> = text.split_whitespace().collect();
-                        let is_bare_command = words.len() == 1
-                            && (which::which(words[0]).is_ok()
-                                || builtins::is_builtin(words[0]));
-
-                        if is_bare_command {
-                            print!("\x1b[90mexplaining...\x1b[0m");
-                            io::stdout().flush().ok();
-                            rt.block_on(async {
-                                match ai::explain_command(&text, &config).await {
-                                    Ok(explanation) => {
-                                        print!("\r\x1b[K");
-                                        eprintln!("\x1b[36m{text}\x1b[0m");
-                                        eprintln!("{explanation}");
-                                    }
-                                    Err(e) => {
-                                        print!("\r\x1b[K");
-                                        eprintln!("shako: ai error: {e}");
-                                        prompt::set_last_status(1);
-                                    }
-                                }
-                            });
-                        } else {
-                            let history = read_recent_history(&history_path, config.behavior.history_context_lines);
-                            match rt.block_on(ai::translate_and_execute(&text, &config, history, &mut state.ai_session_memory)) {
+                            let history = read_recent_history(
+                                &history_path,
+                                config.behavior.history_context_lines,
+                            );
+                            match rt.block_on(ai::translate_and_execute(
+                                &text,
+                                &config,
+                                history,
+                                &mut state.ai_session_memory,
+                            )) {
                                 Ok(_) => prompt::set_last_status(0),
                                 Err(e) => {
                                     eprintln!("shako: ai error: {e}");
@@ -522,18 +511,71 @@ fn main() -> Result<()> {
                                 }
                             }
                         }
+                    }
+                    Classification::ForcedAI(text) => {
+                        if !config.behavior.ai_enabled {
+                            eprintln!("shako: AI is disabled (ai_enabled = false in config)");
+                        } else {
+                            let words: Vec<&str> = text.split_whitespace().collect();
+                            let is_bare_command = words.len() == 1
+                                && (which::which(words[0]).is_ok()
+                                    || builtins::is_builtin(words[0]));
+
+                            if is_bare_command {
+                                print!("\x1b[90mexplaining...\x1b[0m");
+                                io::stdout().flush().ok();
+                                rt.block_on(async {
+                                    match ai::explain_command(&text, &config).await {
+                                        Ok(explanation) => {
+                                            print!("\r\x1b[K");
+                                            eprintln!("\x1b[36m{text}\x1b[0m");
+                                            eprintln!("{explanation}");
+                                        }
+                                        Err(e) => {
+                                            print!("\r\x1b[K");
+                                            eprintln!("shako: ai error: {e}");
+                                            prompt::set_last_status(1);
+                                        }
+                                    }
+                                });
+                            } else {
+                                let history = read_recent_history(
+                                    &history_path,
+                                    config.behavior.history_context_lines,
+                                );
+                                match rt.block_on(ai::translate_and_execute(
+                                    &text,
+                                    &config,
+                                    history,
+                                    &mut state.ai_session_memory,
+                                )) {
+                                    Ok(_) => prompt::set_last_status(0),
+                                    Err(e) => {
+                                        eprintln!("shako: ai error: {e}");
+                                        prompt::set_last_status(1);
+                                    }
+                                }
+                            }
                         } // end ai_enabled check
                     }
                     Classification::Typo { suggestion, .. } => {
                         if config.behavior.auto_correct_typos {
-                            print!(
-                                "\x1b[33mshako: did you mean \x1b[1m{suggestion}\x1b[0m\x1b[33m? [Y/n]\x1b[0m "
-                            );
-                            io::stdout().flush().ok();
-                            let mut answer = String::new();
-                            io::stdin().read_line(&mut answer).ok();
-                            let answer = answer.trim().to_lowercase();
-                            if answer.is_empty() || answer == "y" || answer == "yes" {
+                            let should_run = if config.behavior.confirm_ai_commands {
+                                print!(
+                                    "\x1b[33mshako: did you mean \x1b[1m{suggestion}\x1b[0m\x1b[33m? [Y/n]\x1b[0m "
+                                );
+                                io::stdout().flush().ok();
+                                let mut answer = String::new();
+                                io::stdin().read_line(&mut answer).ok();
+                                let answer = answer.trim().to_lowercase();
+                                answer.is_empty() || answer == "y" || answer == "yes"
+                            } else {
+                                eprintln!(
+                                    "\x1b[33mshako: auto-corrected to \x1b[1m{suggestion}\x1b[0m"
+                                );
+                                true
+                            };
+                            if should_run {
                                 let first = suggestion.split_whitespace().next().unwrap_or("");
                                 if builtins::is_builtin(first) {
                                     let code = builtins::run_builtin(&suggestion, &mut state);
@@ -544,8 +586,16 @@ fn main() -> Result<()> {
                                 }
                             }
                         } else {
-                            let history = read_recent_history(&history_path, config.behavior.history_context_lines);
-                            match rt.block_on(ai::translate_and_execute(&suggestion, &config, history, &mut state.ai_session_memory)) {
+                            let history = read_recent_history(
+                                &history_path,
+                                config.behavior.history_context_lines,
+                            );
+                            match rt.block_on(ai::translate_and_execute(
+                                &suggestion,
+                                &config,
+                                history,
+                                &mut state.ai_session_memory,
+                            )) {
                                 Ok(_) => prompt::set_last_status(0),
                                 Err(e) => {
                                     eprintln!("shako: ai error: {e}");
@@ -555,13 +605,17 @@ fn main() -> Result<()> {
                         }
                     }
                     Classification::Empty => {}
+                    Classification::SlashCommand { name, args } => {
+                        let code = slash::run(&name, &args, &mut config, &rt);
+                        prompt::set_last_status(code);
+                    }
                     Classification::HistorySearch(query) => {
                         if config.behavior.ai_enabled {
-                        let history = read_recent_history(&history_path, 200);
-                        match rt.block_on(ai::search_history(&query, &history, &config)) {
-                            Ok(result) => println!("{result}"),
-                            Err(e) => eprintln!("shako: history search failed: {e}"),
-                        }
+                            let history = read_recent_history(&history_path, 200);
+                            match rt.block_on(ai::search_history(&query, &history, &config)) {
+                                Ok(result) => println!("{result}"),
+                                Err(e) => eprintln!("shako: history search failed: {e}"),
+                            }
                         } else {
                             eprintln!("shako: AI is disabled (ai_enabled = false in config)");
                         }
@@ -570,21 +624,21 @@ fn main() -> Result<()> {
                         if !config.behavior.ai_enabled {
                             eprintln!("shako: AI is disabled (ai_enabled = false in config)");
                         } else {
-                        print!("\x1b[90mexplaining...\x1b[0m");
-                        io::stdout().flush().ok();
-                        rt.block_on(async {
-                            match ai::explain_command(&cmd, &config).await {
-                                Ok(explanation) => {
-                                    print!("\r\x1b[K");
-                                    eprintln!("\x1b[36m{cmd}\x1b[0m");
-                                    eprintln!("{explanation}");
+                            print!("\x1b[90mexplaining...\x1b[0m");
+                            io::stdout().flush().ok();
+                            rt.block_on(async {
+                                match ai::explain_command(&cmd, &config).await {
+                                    Ok(explanation) => {
+                                        print!("\r\x1b[K");
+                                        eprintln!("\x1b[36m{cmd}\x1b[0m");
+                                        eprintln!("{explanation}");
+                                    }
+                                    Err(e) => {
+                                        print!("\r\x1b[K");
+                                        eprintln!("shako: ai error: {e}");
+                                    }
                                 }
-                                Err(e) => {
-                                    print!("\r\x1b[K");
-                                    eprintln!("shako: ai error: {e}");
-                                }
-                            }
-                        });
+                            });
                         } // end ai_enabled check
                     }
                 }
@@ -881,10 +935,7 @@ fn expand_history_bangs(input: &str, last_command: &str) -> String {
         return input.to_string();
     }
 
-    let last_arg = last_command
-        .split_whitespace()
-        .last()
-        .unwrap_or("");
+    let last_arg = last_command.split_whitespace().last().unwrap_or("");
 
     let mut result = input.replace("!!", last_command);
     result = result.replace("!$", last_arg);
@@ -905,10 +956,7 @@ fn read_recent_history(history_path: &std::path::Path, n: usize) -> Vec<String> 
         Ok(contents) => {
             let lines: Vec<&str> = contents.lines().collect();
             let start = lines.len().saturating_sub(n);
-            lines[start..]
-                .iter()
-                .map(|l| l.to_string())
-                .collect()
+            lines[start..].iter().map(|l| l.to_string()).collect()
         }
         Err(_) => Vec::new(),
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -447,15 +447,21 @@ fn expand_brace_param(chars: &[char], i: &mut usize) -> String {
     // Collect everything up to the matching '}'
     let mut depth = 1usize;
     while *i < chars.len() {
-        if chars[*i] == '{' { depth += 1; }
+        if chars[*i] == '{' {
+            depth += 1;
+        }
         if chars[*i] == '}' {
             depth -= 1;
-            if depth == 0 { break; }
+            if depth == 0 {
+                break;
+            }
         }
         *i += 1;
     }
     let inner: String = chars[start..*i].iter().collect();
-    if *i < chars.len() { *i += 1; } // skip '}'
+    if *i < chars.len() {
+        *i += 1;
+    } // skip '}'
 
     // ${#VAR} — string length
     if let Some(varname) = inner.strip_prefix('#') {
@@ -480,14 +486,29 @@ fn expand_brace_param(chars: &[char], i: &mut usize) -> String {
     let value = env::var(varname).unwrap_or_default();
 
     if let Some(word) = rest.strip_prefix(":-") {
-        return if value.is_empty() { word.to_string() } else { value };
+        return if value.is_empty() {
+            word.to_string()
+        } else {
+            value
+        };
     }
     if let Some(word) = rest.strip_prefix(":+") {
-        return if value.is_empty() { String::new() } else { word.to_string() };
+        return if value.is_empty() {
+            String::new()
+        } else {
+            word.to_string()
+        };
     }
     if let Some(word) = rest.strip_prefix(":?") {
         if value.is_empty() {
-            eprintln!("shako: {varname}: {}", if word.is_empty() { "parameter null or not set" } else { word });
+            eprintln!(
+                "shako: {varname}: {}",
+                if word.is_empty() {
+                    "parameter null or not set"
+                } else {
+                    word
+                }
+            );
             return String::new();
         }
         return value;
@@ -583,7 +604,11 @@ fn fnmatch(pat: &str, s: &str) -> bool {
             ([], []) => true,
             (['*', rest_p @ ..], _) => {
                 // * matches 0 or more chars
-                for i in 0..=s.len() { if m(rest_p, &s[i..]) { return true; } }
+                for i in 0..=s.len() {
+                    if m(rest_p, &s[i..]) {
+                        return true;
+                    }
+                }
                 false
             }
             (['?', rest_p @ ..], [_, rest_s @ ..]) => m(rest_p, rest_s),
@@ -593,8 +618,6 @@ fn fnmatch(pat: &str, s: &str) -> bool {
     }
     m(&pat, &s)
 }
-
-
 
 /// Expand a glob pattern into matching file paths.
 fn expand_glob(pattern: &str) -> Option<Vec<String>> {
@@ -711,7 +734,11 @@ fn arith_parse_cmp(chars: &[char], pos: &mut usize) -> i64 {
         return left;
     }
     let c = chars[*pos];
-    let n = if *pos + 1 < chars.len() { chars[*pos + 1] } else { '\0' };
+    let n = if *pos + 1 < chars.len() {
+        chars[*pos + 1]
+    } else {
+        '\0'
+    };
     if c == '=' && n == '=' {
         *pos += 2;
         let right = arith_parse_add(chars, pos);
@@ -762,7 +789,8 @@ fn arith_parse_mul(chars: &[char], pos: &mut usize) -> i64 {
     let mut left = arith_parse_pow(chars, pos);
     loop {
         arith_skip_ws(chars, pos);
-        if *pos < chars.len() && chars[*pos] == '*'
+        if *pos < chars.len()
+            && chars[*pos] == '*'
             && (*pos + 1 >= chars.len() || chars[*pos + 1] != '*')
         {
             *pos += 1;
@@ -788,7 +816,9 @@ fn arith_parse_pow(chars: &[char], pos: &mut usize) -> i64 {
     if *pos + 1 < chars.len() && chars[*pos] == '*' && chars[*pos + 1] == '*' {
         *pos += 2;
         let exp = arith_parse_unary(chars, pos);
-        if exp < 0 { return 0; }
+        if exp < 0 {
+            return 0;
+        }
         base.wrapping_pow(exp as u32)
     } else {
         base
@@ -1316,7 +1346,10 @@ mod tests {
     #[test]
     fn test_tokenize_whitespace_only() {
         let tokens = tokenize("   \t  ");
-        assert!(tokens.is_empty(), "whitespace-only input should produce no tokens");
+        assert!(
+            tokens.is_empty(),
+            "whitespace-only input should produce no tokens"
+        );
     }
 
     #[test]
@@ -1328,7 +1361,10 @@ mod tests {
     #[test]
     fn test_parse_args_whitespace_only() {
         let args = parse_args("   ");
-        assert!(args.is_empty(), "whitespace-only input should produce no args");
+        assert!(
+            args.is_empty(),
+            "whitespace-only input should produce no args"
+        );
     }
 
     // ── Edge case: $() command substitution inside double quotes ─

--- a/src/proactive.rs
+++ b/src/proactive.rs
@@ -105,12 +105,19 @@ fn get_staged_info() -> Option<StagedInfo> {
     let full_diff = String::from_utf8_lossy(&diff_out.stdout).to_string();
     const DIFF_CAP: usize = 4_000;
     let diff = if full_diff.len() > DIFF_CAP {
-        format!("{}\n[...diff truncated at {DIFF_CAP} bytes...]", &full_diff[..DIFF_CAP])
+        format!(
+            "{}\n[...diff truncated at {DIFF_CAP} bytes...]",
+            &full_diff[..DIFF_CAP]
+        )
     } else {
         full_diff
     };
 
-    Some(StagedInfo { stat, diff, file_count })
+    Some(StagedInfo {
+        stat,
+        diff,
+        file_count,
+    })
 }
 
 /// Offer an AI-generated commit message to the user.
@@ -119,7 +126,11 @@ fn offer_commit_suggestion(config: &ShakoConfig, rt: &tokio::runtime::Runtime) {
         return;
     };
 
-    let file_word = if staged.file_count == 1 { "file" } else { "files" };
+    let file_word = if staged.file_count == 1 {
+        "file"
+    } else {
+        "files"
+    };
     print!(
         "\x1b[90mshako: {} {} staged — suggest a commit message? [y/N] \x1b[0m",
         staged.file_count, file_word
@@ -196,7 +207,11 @@ fn extract_repo_name(url: &str) -> Option<String> {
     let segment = url.split('/').next_back()?;
     // Strip .git suffix
     let name = segment.strip_suffix(".git").unwrap_or(segment);
-    if name.is_empty() { None } else { Some(name.to_string()) }
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
 }
 
 /// Parse a Makefile and return the list of public targets (no leading dot/underscore,
@@ -247,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_is_git_add_excluded() {
-        assert!(!is_git_add("git add"));           // no target
+        assert!(!is_git_add("git add")); // no target
         assert!(!is_git_add("git add --help"));
         assert!(!is_git_add("git add --version"));
         assert!(!is_git_add("git commit -m test"));
@@ -263,7 +278,10 @@ mod tests {
     #[test]
     fn test_shell_quote_has_double_quotes() {
         // falls back to single quotes when message contains "
-        assert_eq!(shell_quote(r#"fix: handle "empty" input"#), r#"'fix: handle "empty" input'"#);
+        assert_eq!(
+            shell_quote(r#"fix: handle "empty" input"#),
+            r#"'fix: handle "empty" input'"#
+        );
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -73,11 +73,7 @@ pub fn run_wizard(config_path: &Path) -> Result<String> {
                 " \x1b[36m?\x1b[0m Found fish config at \x1b[33m{}\x1b[0m",
                 fd.display()
             )?;
-            let answer = prompt_line(
-                &mut out,
-                " Import fish config into shako? [Y/n]: ",
-                "y",
-            )?;
+            let answer = prompt_line(&mut out, " Import fish config into shako? [Y/n]: ", "y")?;
             if matches!(answer.trim().to_lowercase().as_str(), "" | "y" | "yes") {
                 writeln!(out)?;
                 drop(out);
@@ -165,18 +161,12 @@ fn wizard_custom_proxy(out: &mut impl Write) -> Result<String> {
     let mut endpoint = endpoint.trim().to_string();
     if !endpoint.starts_with("http://") && !endpoint.starts_with("https://") {
         endpoint = format!("https://{endpoint}");
-        writeln!(
-            out,
-            " \x1b[90m(added https:// → {endpoint})\x1b[0m"
-        )?;
+        writeln!(out, " \x1b[90m(added https:// → {endpoint})\x1b[0m")?;
     }
     if let Ok(parsed) = reqwest::Url::parse(&endpoint) {
         if parsed.path() == "/" || parsed.path().is_empty() {
             endpoint = format!("{}/v1/chat/completions", endpoint.trim_end_matches('/'));
-            writeln!(
-                out,
-                " \x1b[90m(added API path → {endpoint})\x1b[0m"
-            )?;
+            writeln!(out, " \x1b[90m(added API path → {endpoint})\x1b[0m")?;
         }
     }
 
@@ -354,15 +344,50 @@ fn prompt_line(out: &mut impl Write, prompt: &str, default: &str) -> Result<Stri
 /// Recommended tools with (binary, name, description, impact level).
 /// Impact: "core" = significant shako experience uplift, "nice" = useful but optional.
 const RECOMMENDED_TOOLS: &[(&str, &str, &str, &str)] = &[
-    ("starship", "Starship", "cross-shell prompt with git, rust, node info", "core"),
-    ("eza", "eza", "modern ls with icons, git status, tree view", "core"),
-    ("bat", "bat", "cat with syntax highlighting and line numbers", "core"),
+    (
+        "starship",
+        "Starship",
+        "cross-shell prompt with git, rust, node info",
+        "core",
+    ),
+    (
+        "eza",
+        "eza",
+        "modern ls with icons, git status, tree view",
+        "core",
+    ),
+    (
+        "bat",
+        "bat",
+        "cat with syntax highlighting and line numbers",
+        "core",
+    ),
     ("fd", "fd", "faster find with simpler syntax", "core"),
-    ("rg", "ripgrep", "faster grep that respects .gitignore", "core"),
-    ("zoxide", "zoxide", "smart cd that learns your habits (powers z/zi)", "core"),
-    ("fzf", "fzf", "fuzzy finder for interactive selection (powers zi)", "core"),
+    (
+        "rg",
+        "ripgrep",
+        "faster grep that respects .gitignore",
+        "core",
+    ),
+    (
+        "zoxide",
+        "zoxide",
+        "smart cd that learns your habits (powers z/zi)",
+        "core",
+    ),
+    (
+        "fzf",
+        "fzf",
+        "fuzzy finder for interactive selection (powers zi)",
+        "core",
+    ),
     ("dust", "dust", "visual disk usage (replaces du)", "nice"),
-    ("delta", "delta", "side-by-side diff with syntax highlighting", "nice"),
+    (
+        "delta",
+        "delta",
+        "side-by-side diff with syntax highlighting",
+        "nice",
+    ),
     ("procs", "procs", "modern ps with color and search", "nice"),
     ("sd", "sd", "simpler sed for find-and-replace", "nice"),
 ];
@@ -403,11 +428,7 @@ pub fn check_recommended_tools() {
     writeln!(out).ok();
 
     if all_installed {
-        writeln!(
-            out,
-            " \x1b[32m✓ All recommended tools installed!\x1b[0m\n"
-        )
-        .ok();
+        writeln!(out, " \x1b[32m✓ All recommended tools installed!\x1b[0m\n").ok();
         return;
     }
 
@@ -426,17 +447,9 @@ pub fn check_recommended_tools() {
     if !missing_nice.is_empty() {
         let tools = missing_nice.join(" ");
         if missing_core.is_empty() {
-            writeln!(
-                out,
-                " \x1b[90mOptional:\x1b[0m\n   {install_cmd} {tools}"
-            )
-            .ok();
+            writeln!(out, " \x1b[90mOptional:\x1b[0m\n   {install_cmd} {tools}").ok();
         } else {
-            writeln!(
-                out,
-                "\n \x1b[90mOptional:\x1b[0m\n   {install_cmd} {tools}"
-            )
-            .ok();
+            writeln!(out, "\n \x1b[90mOptional:\x1b[0m\n   {install_cmd} {tools}").ok();
         }
     }
 

--- a/src/shell/completer.rs
+++ b/src/shell/completer.rs
@@ -6,35 +6,86 @@ use std::sync::{Arc, RwLock};
 use crate::path_cache::PathCache;
 
 const GIT_COMMIT_FLAGS: &[&str] = &[
-    "--message", "--amend", "--all", "--no-edit", "--allow-empty",
-    "--author", "--date", "--signoff", "--verbose", "--dry-run",
+    "--message",
+    "--amend",
+    "--all",
+    "--no-edit",
+    "--allow-empty",
+    "--author",
+    "--date",
+    "--signoff",
+    "--verbose",
+    "--dry-run",
 ];
 const GIT_LOG_FLAGS: &[&str] = &[
-    "--oneline", "--graph", "--all", "--author", "--since", "--until",
-    "--stat", "--patch", "--follow", "--decorate", "--format",
+    "--oneline",
+    "--graph",
+    "--all",
+    "--author",
+    "--since",
+    "--until",
+    "--stat",
+    "--patch",
+    "--follow",
+    "--decorate",
+    "--format",
 ];
 const GIT_PUSH_FLAGS: &[&str] = &[
-    "--force", "--force-with-lease", "--set-upstream", "--tags",
-    "--dry-run", "--verbose", "--all",
+    "--force",
+    "--force-with-lease",
+    "--set-upstream",
+    "--tags",
+    "--dry-run",
+    "--verbose",
+    "--all",
 ];
 const GIT_PULL_FLAGS: &[&str] = &[
-    "--rebase", "--no-rebase", "--ff-only", "--all", "--tags", "--verbose",
+    "--rebase",
+    "--no-rebase",
+    "--ff-only",
+    "--all",
+    "--tags",
+    "--verbose",
 ];
 const GIT_DIFF_FLAGS: &[&str] = &[
-    "--stat", "--name-only", "--cached", "--staged", "--word-diff",
-    "--color-words", "--unified",
+    "--stat",
+    "--name-only",
+    "--cached",
+    "--staged",
+    "--word-diff",
+    "--color-words",
+    "--unified",
 ];
 const CARGO_BUILD_FLAGS: &[&str] = &[
-    "--release", "--features", "--all-features", "--no-default-features",
-    "--target", "--manifest-path", "--verbose", "--quiet",
+    "--release",
+    "--features",
+    "--all-features",
+    "--no-default-features",
+    "--target",
+    "--manifest-path",
+    "--verbose",
+    "--quiet",
 ];
 const CARGO_TEST_FLAGS: &[&str] = &[
-    "--release", "--features", "--all-features", "--no-default-features",
-    "--verbose", "--quiet", "--no-run", "--test", "--lib", "--bin",
+    "--release",
+    "--features",
+    "--all-features",
+    "--no-default-features",
+    "--verbose",
+    "--quiet",
+    "--no-run",
+    "--test",
+    "--lib",
+    "--bin",
 ];
 const CARGO_RUN_FLAGS: &[&str] = &[
-    "--release", "--features", "--all-features", "--bin",
-    "--example", "--manifest-path", "--verbose",
+    "--release",
+    "--features",
+    "--all-features",
+    "--bin",
+    "--example",
+    "--manifest-path",
+    "--verbose",
 ];
 
 const GIT_SUBCOMMANDS: &[&str] = &[
@@ -122,63 +173,239 @@ const KUBECTL_SUBCOMMANDS: &[&str] = &[
 ];
 
 const NPM_SUBCOMMANDS: &[&str] = &[
-    "audit", "cache", "ci", "dedupe", "exec", "fund", "help", "init", "install",
-    "link", "list", "login", "logout", "outdated", "pack", "ping", "prefix",
-    "publish", "rebuild", "restart", "root", "run", "set", "start", "stop",
-    "test", "token", "uninstall", "unpublish", "update", "version", "view", "whoami",
+    "audit",
+    "cache",
+    "ci",
+    "dedupe",
+    "exec",
+    "fund",
+    "help",
+    "init",
+    "install",
+    "link",
+    "list",
+    "login",
+    "logout",
+    "outdated",
+    "pack",
+    "ping",
+    "prefix",
+    "publish",
+    "rebuild",
+    "restart",
+    "root",
+    "run",
+    "set",
+    "start",
+    "stop",
+    "test",
+    "token",
+    "uninstall",
+    "unpublish",
+    "update",
+    "version",
+    "view",
+    "whoami",
 ];
 
 const PNPM_SUBCOMMANDS: &[&str] = &[
-    "add", "audit", "ci", "dedupe", "exec", "import", "init", "install", "licenses",
-    "link", "list", "outdated", "pack", "patch", "publish", "rebuild", "remove",
-    "run", "start", "store", "test", "unlink", "update", "why",
+    "add", "audit", "ci", "dedupe", "exec", "import", "init", "install", "licenses", "link",
+    "list", "outdated", "pack", "patch", "publish", "rebuild", "remove", "run", "start", "store",
+    "test", "unlink", "update", "why",
 ];
 
 const YARN_SUBCOMMANDS: &[&str] = &[
-    "add", "audit", "autoclean", "bin", "cache", "check", "config", "create",
-    "exec", "global", "help", "import", "info", "init", "install", "licenses",
-    "link", "list", "login", "logout", "outdated", "owner", "pack", "policies",
-    "publish", "remove", "run", "tag", "team", "test", "unlink", "upgrade",
-    "upgrade-interactive", "version", "versions", "why", "workspace", "workspaces",
+    "add",
+    "audit",
+    "autoclean",
+    "bin",
+    "cache",
+    "check",
+    "config",
+    "create",
+    "exec",
+    "global",
+    "help",
+    "import",
+    "info",
+    "init",
+    "install",
+    "licenses",
+    "link",
+    "list",
+    "login",
+    "logout",
+    "outdated",
+    "owner",
+    "pack",
+    "policies",
+    "publish",
+    "remove",
+    "run",
+    "tag",
+    "team",
+    "test",
+    "unlink",
+    "upgrade",
+    "upgrade-interactive",
+    "version",
+    "versions",
+    "why",
+    "workspace",
+    "workspaces",
 ];
 
 const BUN_SUBCOMMANDS: &[&str] = &[
-    "add", "build", "create", "dev", "exec", "init", "install", "link", "outdated",
-    "patch", "pm", "publish", "remove", "run", "test", "unlink", "update", "upgrade", "x",
+    "add", "build", "create", "dev", "exec", "init", "install", "link", "outdated", "patch", "pm",
+    "publish", "remove", "run", "test", "unlink", "update", "upgrade", "x",
 ];
 
 const BREW_SUBCOMMANDS: &[&str] = &[
-    "analytics", "audit", "autoremove", "bundle", "cask", "cleanup", "commands",
-    "completions", "config", "deps", "desc", "developer", "doctor", "edit",
-    "fetch", "formulae", "gist-logs", "help", "home", "info", "install", "leaves",
-    "link", "list", "log", "missing", "options", "outdated", "pin", "postinstall",
-    "readall", "reinstall", "search", "services", "shellenv", "style", "tap",
-    "tap-info", "uninstall", "unlink", "unpin", "untap", "update", "upgrade",
-    "uses", "vendor-gems",
+    "analytics",
+    "audit",
+    "autoremove",
+    "bundle",
+    "cask",
+    "cleanup",
+    "commands",
+    "completions",
+    "config",
+    "deps",
+    "desc",
+    "developer",
+    "doctor",
+    "edit",
+    "fetch",
+    "formulae",
+    "gist-logs",
+    "help",
+    "home",
+    "info",
+    "install",
+    "leaves",
+    "link",
+    "list",
+    "log",
+    "missing",
+    "options",
+    "outdated",
+    "pin",
+    "postinstall",
+    "readall",
+    "reinstall",
+    "search",
+    "services",
+    "shellenv",
+    "style",
+    "tap",
+    "tap-info",
+    "uninstall",
+    "unlink",
+    "unpin",
+    "untap",
+    "update",
+    "upgrade",
+    "uses",
+    "vendor-gems",
 ];
 
 const GO_SUBCOMMANDS: &[&str] = &[
-    "build", "clean", "doc", "env", "fix", "fmt", "generate", "get", "help",
-    "install", "list", "mod", "run", "telemetry", "test", "tool", "vet", "version", "work",
+    "build",
+    "clean",
+    "doc",
+    "env",
+    "fix",
+    "fmt",
+    "generate",
+    "get",
+    "help",
+    "install",
+    "list",
+    "mod",
+    "run",
+    "telemetry",
+    "test",
+    "tool",
+    "vet",
+    "version",
+    "work",
 ];
 
 const RUSTUP_SUBCOMMANDS: &[&str] = &[
-    "check", "component", "completions", "default", "doc", "help", "man",
-    "override", "run", "self", "set", "show", "target", "toolchain", "uninstall",
-    "update", "which",
+    "check",
+    "component",
+    "completions",
+    "default",
+    "doc",
+    "help",
+    "man",
+    "override",
+    "run",
+    "self",
+    "set",
+    "show",
+    "target",
+    "toolchain",
+    "uninstall",
+    "update",
+    "which",
 ];
 
 const HELM_SUBCOMMANDS: &[&str] = &[
-    "completion", "create", "dependency", "diff", "env", "get", "help", "history",
-    "install", "lint", "list", "package", "plugin", "pull", "push", "registry",
-    "repo", "rollback", "search", "show", "status", "template", "test",
-    "uninstall", "upgrade", "verify", "version",
+    "completion",
+    "create",
+    "dependency",
+    "diff",
+    "env",
+    "get",
+    "help",
+    "history",
+    "install",
+    "lint",
+    "list",
+    "package",
+    "plugin",
+    "pull",
+    "push",
+    "registry",
+    "repo",
+    "rollback",
+    "search",
+    "show",
+    "status",
+    "template",
+    "test",
+    "uninstall",
+    "upgrade",
+    "verify",
+    "version",
 ];
 
 const TERRAFORM_SUBCOMMANDS: &[&str] = &[
-    "apply", "console", "destroy", "fmt", "force-unlock", "get", "graph", "import",
-    "init", "login", "logout", "metadata", "modules", "output", "plan", "providers",
-    "refresh", "show", "state", "taint", "test", "untaint", "validate", "version",
+    "apply",
+    "console",
+    "destroy",
+    "fmt",
+    "force-unlock",
+    "get",
+    "graph",
+    "import",
+    "init",
+    "login",
+    "logout",
+    "metadata",
+    "modules",
+    "output",
+    "plan",
+    "providers",
+    "refresh",
+    "show",
+    "state",
+    "taint",
+    "test",
+    "untaint",
+    "validate",
+    "version",
     "workspace",
 ];
 
@@ -186,8 +413,16 @@ const MAKE_SUBCOMMANDS: &[&str] = &[];
 
 /// Commands where the next argument is a git branch/ref name.
 const GIT_BRANCH_CMDS: &[&str] = &[
-    "checkout", "switch", "merge", "rebase", "diff", "log",
-    "cherry-pick", "push", "pull", "branch",
+    "checkout",
+    "switch",
+    "merge",
+    "rebase",
+    "diff",
+    "log",
+    "cherry-pick",
+    "push",
+    "pull",
+    "branch",
 ];
 
 pub struct ShakoCompleter {
@@ -198,7 +433,10 @@ pub struct ShakoCompleter {
 
 impl ShakoCompleter {
     pub fn new(cache: Arc<PathCache>, extra_completions: Arc<RwLock<Vec<String>>>) -> Self {
-        Self { cache, extra_completions }
+        Self {
+            cache,
+            extra_completions,
+        }
     }
 
     /// Run `git branch` and return matching branch names as completions.
@@ -243,8 +481,12 @@ impl ShakoCompleter {
         let config_path = dirs::home_dir()
             .map(|h| h.join(".ssh/config"))
             .filter(|p| p.exists());
-        let Some(path) = config_path else { return vec![] };
-        let Ok(contents) = fs::read_to_string(&path) else { return vec![] };
+        let Some(path) = config_path else {
+            return vec![];
+        };
+        let Ok(contents) = fs::read_to_string(&path) else {
+            return vec![];
+        };
         // Filter fully before calling to_string() — only allocate for matching hosts.
         let mut hosts: Vec<String> = contents
             .lines()
@@ -525,7 +767,8 @@ impl Completer for ShakoCompleter {
 
         // After `sudo`, complete like a first token
         if first_cmd == "sudo" && parts.len() == 2 && !line_to_cursor.ends_with(' ') {
-            return self.path_commands()
+            return self
+                .path_commands()
                 .iter()
                 .filter(|cmd| cmd.starts_with(partial))
                 .map(|cmd| Suggestion {
@@ -646,8 +889,8 @@ impl Completer for ShakoCompleter {
         if first_cmd == "git" {
             let subcmd = if parts.len() >= 2 { parts[1] } else { "" };
             let is_branch_cmd = GIT_BRANCH_CMDS.contains(&subcmd);
-            let past_subcmd = (parts.len() >= 3)
-                || (parts.len() == 2 && line_to_cursor.ends_with(' '));
+            let past_subcmd =
+                (parts.len() >= 3) || (parts.len() == 2 && line_to_cursor.ends_with(' '));
             if is_branch_cmd && past_subcmd {
                 let branches = self.git_branches(partial, start, pos);
                 if !branches.is_empty() {
@@ -679,10 +922,20 @@ mod tests {
     fn test_cd_with_trailing_space_returns_dirs() {
         let mut c = test_completer();
         let suggestions = c.complete("cd ", 3);
-        assert!(!suggestions.is_empty(), "expected directory completions for 'cd '");
+        assert!(
+            !suggestions.is_empty(),
+            "expected directory completions for 'cd '"
+        );
         for s in &suggestions {
-            assert!(s.value.ends_with('/'), "dir completion '{}' should end with '/'", s.value);
-            assert!(!s.append_whitespace, "dir completion should not append whitespace");
+            assert!(
+                s.value.ends_with('/'),
+                "dir completion '{}' should end with '/'",
+                s.value
+            );
+            assert!(
+                !s.append_whitespace,
+                "dir completion should not append whitespace"
+            );
         }
         assert_eq!(suggestions[0].span.start, 3);
         assert_eq!(suggestions[0].span.end, 3);
@@ -694,7 +947,11 @@ mod tests {
         // repo root contains src/ — "cat sr" should complete to "src/"
         let suggestions = c.complete("cat sr", 6);
         let src = suggestions.iter().find(|s| s.value == "src/");
-        assert!(src.is_some(), "expected 'src/' in completions, got: {:?}", suggestions.iter().map(|s| &s.value).collect::<Vec<_>>());
+        assert!(
+            src.is_some(),
+            "expected 'src/' in completions, got: {:?}",
+            suggestions.iter().map(|s| &s.value).collect::<Vec<_>>()
+        );
         let src = src.unwrap();
         assert!(!src.append_whitespace);
         assert_eq!(src.span.start, 4);
@@ -707,7 +964,11 @@ mod tests {
         let suggestions = c.complete("cat src/", 8);
         assert!(!suggestions.is_empty(), "expected completions inside src/");
         for s in &suggestions {
-            assert!(s.value.starts_with("src/"), "completion '{}' should start with 'src/'", s.value);
+            assert!(
+                s.value.starts_with("src/"),
+                "completion '{}' should start with 'src/'",
+                s.value
+            );
         }
         assert_eq!(suggestions[0].span.start, 4);
         assert_eq!(suggestions[0].span.end, 8);
@@ -717,14 +978,20 @@ mod tests {
     fn test_first_token_completion() {
         let mut c = test_completer();
         let suggestions = c.complete("gi", 2);
-        assert!(suggestions.iter().any(|s| s.value == "git"), "expected 'git' in command completions");
+        assert!(
+            suggestions.iter().any(|s| s.value == "git"),
+            "expected 'git' in command completions"
+        );
     }
 
     #[test]
     fn test_git_subcommand_completion() {
         let mut c = test_completer();
         let suggestions = c.complete("git stat", 8);
-        assert!(suggestions.iter().any(|s| s.value == "status"), "expected 'status' in git subcommand completions");
+        assert!(
+            suggestions.iter().any(|s| s.value == "status"),
+            "expected 'status' in git subcommand completions"
+        );
     }
 
     #[test]
@@ -753,10 +1020,17 @@ mod tests {
         if let Some(home) = dirs::home_dir() {
             if home.is_dir() {
                 let suggestions = c.complete("ls ~/", 5);
-                assert!(!suggestions.is_empty(), "tilde path '~/' should expand to home dir and return entries");
+                assert!(
+                    !suggestions.is_empty(),
+                    "tilde path '~/' should expand to home dir and return entries"
+                );
                 // All values should be prefixed with "~/"
                 for s in &suggestions {
-                    assert!(s.value.starts_with("~/"), "completion '{}' should start with '~/'", s.value);
+                    assert!(
+                        s.value.starts_with("~/"),
+                        "completion '{}' should start with '~/'",
+                        s.value
+                    );
                 }
             }
         }

--- a/src/shell/highlighter.rs
+++ b/src/shell/highlighter.rs
@@ -284,8 +284,13 @@ fn tokenize_for_highlighting(line: &str) -> Vec<HlToken> {
         if c == '-' && (i == 0 || chars[i - 1].is_whitespace()) {
             let start = i;
             i += 1;
-            while i < len && !chars[i].is_whitespace() && chars[i] != '|' && chars[i] != '>'
-                && chars[i] != '<' && chars[i] != ';' && chars[i] != '&'
+            while i < len
+                && !chars[i].is_whitespace()
+                && chars[i] != '|'
+                && chars[i] != '>'
+                && chars[i] != '<'
+                && chars[i] != ';'
+                && chars[i] != '&'
             {
                 i += 1;
             }

--- a/src/shell/prompt.rs
+++ b/src/shell/prompt.rs
@@ -147,7 +147,11 @@ impl Prompt for StarshipPrompt {
         }
 
         // Join the thread started during left render.
-        let handle = self.right_handle.lock().unwrap_or_else(|e| e.into_inner()).take();
+        let handle = self
+            .right_handle
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
         match handle {
             Some(h) => Cow::Owned(h.join().unwrap_or_default()),
             // Fallback: render inline if left wasn't called first (shouldn't happen).

--- a/src/slash.rs
+++ b/src/slash.rs
@@ -1,0 +1,285 @@
+use crate::ai;
+use crate::config::ShakoConfig;
+
+pub const SLASH_COMMANDS: &[(&str, &str)] = &[
+    ("help", "List available slash commands"),
+    ("validate", "Validate the AI endpoint connection"),
+    ("config", "Show current configuration"),
+    ("model", "Show or switch the active AI model/provider"),
+    ("safety", "Show or change safety mode (warn/block/off)"),
+    ("provider", "Show or switch the active LLM provider"),
+];
+
+pub fn run(name: &str, args: &str, config: &mut ShakoConfig, rt: &tokio::runtime::Runtime) -> i32 {
+    match name {
+        "help" => cmd_help(),
+        "validate" => cmd_validate(config, rt),
+        "config" => cmd_config(config),
+        "model" => cmd_model(args, config),
+        "safety" => cmd_safety(args, config),
+        "provider" => cmd_provider(args, config),
+        _ => {
+            eprintln!("shako: unknown command /{name}");
+            eprintln!("       run /help to see available commands");
+            1
+        }
+    }
+}
+
+fn cmd_help() -> i32 {
+    eprintln!("\x1b[1mshako slash commands\x1b[0m\n");
+    for (name, desc) in SLASH_COMMANDS {
+        eprintln!("  \x1b[36m/{name:<12}\x1b[0m {desc}");
+    }
+    eprintln!();
+    0
+}
+
+fn cmd_validate(config: &ShakoConfig, rt: &tokio::runtime::Runtime) -> i32 {
+    let llm = config.active_llm();
+    let provider_label = config.active_provider.as_deref().unwrap_or("llm (default)");
+
+    eprintln!("\x1b[90mvalidating provider \x1b[1m{provider_label}\x1b[0m\x1b[90m...\x1b[0m");
+    eprintln!("  endpoint:  {}", llm.endpoint);
+    eprintln!("  model:     {}", llm.model);
+    eprintln!(
+        "  api key:   {} {}",
+        llm.api_key_env,
+        if std::env::var(&llm.api_key_env).is_ok() {
+            "(set)"
+        } else {
+            "(not set)"
+        }
+    );
+
+    let result = rt.block_on(ai::client::check_ai_session(
+        llm,
+        config.behavior.ai_enabled,
+    ));
+
+    match result {
+        ai::client::AiCheckResult::Ready => {
+            eprintln!("\x1b[32m  status:    ready\x1b[0m");
+            0
+        }
+        ai::client::AiCheckResult::Disabled => {
+            eprintln!("\x1b[33m  status:    AI disabled (ai_enabled = false)\x1b[0m");
+            0
+        }
+        ai::client::AiCheckResult::NoApiKey(env_var) => {
+            eprintln!("\x1b[31m  status:    no API key (set ${env_var})\x1b[0m");
+            1
+        }
+        ai::client::AiCheckResult::AuthFailed(code) => {
+            eprintln!("\x1b[31m  status:    auth failed (HTTP {code})\x1b[0m");
+            1
+        }
+        ai::client::AiCheckResult::Unreachable(reason) => {
+            eprintln!("\x1b[31m  status:    unreachable ({reason})\x1b[0m");
+            1
+        }
+    }
+}
+
+fn cmd_config(config: &ShakoConfig) -> i32 {
+    let llm = config.active_llm();
+    let provider_label = config.active_provider.as_deref().unwrap_or("llm (default)");
+
+    eprintln!("\x1b[1mshako configuration\x1b[0m\n");
+
+    eprintln!("\x1b[36m[active provider: {provider_label}]\x1b[0m");
+    eprintln!("  endpoint         = {}", llm.endpoint);
+    eprintln!("  model            = {}", llm.model);
+    eprintln!("  api_key_env      = {}", llm.api_key_env);
+    eprintln!("  timeout_secs     = {}", llm.timeout_secs);
+    eprintln!("  max_tokens       = {}", llm.max_tokens);
+    eprintln!("  temperature      = {}", llm.temperature);
+    eprintln!("  verify_ssl       = {}", llm.verify_ssl);
+
+    if !config.providers.is_empty() {
+        eprintln!("\n\x1b[36m[providers]\x1b[0m");
+        for name in config.providers.keys() {
+            let marker = if config.active_provider.as_deref() == Some(name) {
+                " (active)"
+            } else {
+                ""
+            };
+            eprintln!("  {name}{marker}");
+        }
+    }
+
+    eprintln!("\n\x1b[36m[behavior]\x1b[0m");
+    eprintln!("  ai_enabled           = {}", config.behavior.ai_enabled);
+    eprintln!(
+        "  confirm_ai_commands  = {}",
+        config.behavior.confirm_ai_commands
+    );
+    eprintln!(
+        "  auto_correct_typos   = {}",
+        config.behavior.auto_correct_typos
+    );
+    eprintln!("  safety_mode          = {}", config.behavior.safety_mode);
+    eprintln!("  edit_mode            = {}", config.behavior.edit_mode);
+    eprintln!(
+        "  history_context      = {}",
+        config.behavior.history_context_lines
+    );
+
+    if !config.aliases.is_empty() {
+        eprintln!("\n\x1b[36m[aliases]\x1b[0m");
+        for (k, v) in &config.aliases {
+            eprintln!("  {k} = {v}");
+        }
+    }
+
+    eprintln!();
+    0
+}
+
+fn cmd_model(args: &str, config: &ShakoConfig) -> i32 {
+    if args.is_empty() {
+        let llm = config.active_llm();
+        let provider_label = config.active_provider.as_deref().unwrap_or("llm (default)");
+        eprintln!("\x1b[36m{provider_label}\x1b[0m: {}", llm.model);
+        return 0;
+    }
+    eprintln!("shako: runtime model switching not yet supported");
+    eprintln!("       edit ~/.config/shako/config.toml to change models");
+    1
+}
+
+fn cmd_safety(args: &str, config: &mut ShakoConfig) -> i32 {
+    if args.is_empty() {
+        eprintln!(
+            "safety_mode = \x1b[1m{}\x1b[0m",
+            config.behavior.safety_mode
+        );
+        eprintln!("  warn  — show warning for dangerous commands");
+        eprintln!("  block — block dangerous commands entirely");
+        eprintln!("  off   — no safety checks");
+        return 0;
+    }
+
+    match args {
+        "warn" | "block" | "off" => {
+            config.behavior.safety_mode = args.to_string();
+            eprintln!("safety_mode = \x1b[1m{args}\x1b[0m (session only)");
+            0
+        }
+        _ => {
+            eprintln!("shako: invalid safety mode '{args}'");
+            eprintln!("       valid modes: warn, block, off");
+            1
+        }
+    }
+}
+
+fn cmd_provider(args: &str, config: &mut ShakoConfig) -> i32 {
+    if args.is_empty() {
+        let current = config
+            .active_provider
+            .as_deref()
+            .unwrap_or("(default [llm])");
+        eprintln!("active provider: \x1b[1m{current}\x1b[0m");
+        if !config.providers.is_empty() {
+            eprintln!("\navailable providers:");
+            for (name, p) in &config.providers {
+                let marker = if config.active_provider.as_deref() == Some(name.as_str()) {
+                    " \x1b[32m(active)\x1b[0m"
+                } else {
+                    ""
+                };
+                eprintln!("  \x1b[36m{name}\x1b[0m — {}{marker}", p.model);
+            }
+        }
+        return 0;
+    }
+
+    if config.providers.contains_key(args) {
+        config.active_provider = Some(args.to_string());
+        let model = &config.providers[args].model;
+        eprintln!("switched to \x1b[1m{args}\x1b[0m ({model}) (session only)");
+        0
+    } else {
+        eprintln!("shako: unknown provider '{args}'");
+        if !config.providers.is_empty() {
+            let names: Vec<&str> = config.providers.keys().map(|s| s.as_str()).collect();
+            eprintln!("       available: {}", names.join(", "));
+        }
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slash_commands_list_not_empty() {
+        assert!(!SLASH_COMMANDS.is_empty());
+    }
+
+    #[test]
+    fn test_unknown_command_returns_1() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("nonexistent", "", &mut config, &rt), 1);
+    }
+
+    #[test]
+    fn test_help_returns_0() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("help", "", &mut config, &rt), 0);
+    }
+
+    #[test]
+    fn test_config_returns_0() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("config", "", &mut config, &rt), 0);
+    }
+
+    #[test]
+    fn test_model_no_args_returns_0() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("model", "", &mut config, &rt), 0);
+    }
+
+    #[test]
+    fn test_safety_no_args_returns_0() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("safety", "", &mut config, &rt), 0);
+    }
+
+    #[test]
+    fn test_safety_set_valid_mode() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("safety", "off", &mut config, &rt), 0);
+        assert_eq!(config.behavior.safety_mode, "off");
+    }
+
+    #[test]
+    fn test_safety_set_invalid_mode() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("safety", "invalid", &mut config, &rt), 1);
+    }
+
+    #[test]
+    fn test_provider_no_args_returns_0() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("provider", "", &mut config, &rt), 0);
+    }
+
+    #[test]
+    fn test_provider_switch_unknown() {
+        let mut config = ShakoConfig::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        assert_eq!(run("provider", "nonexistent", &mut config, &rt), 1);
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -69,7 +69,10 @@ fn test_pipe_multi() {
     let out = shako("echo -e 'c\nb\na' | sort | head -1");
     let result = stdout(&out).trim().to_string();
     // On macOS, echo -e may not be supported; accept either result
-    assert!(result == "a" || result.contains("a"), "sort should produce 'a' first, got: {result}");
+    assert!(
+        result == "a" || result.contains("a"),
+        "sort should produce 'a' first, got: {result}"
+    );
 }
 
 #[test]
@@ -371,7 +374,10 @@ fn test_popd_returns_to_original() {
     let lines: Vec<&str> = s.trim().lines().collect();
     let last = lines.last().unwrap_or(&"");
     // Should be back to the original dir (not /tmp)
-    assert!(!last.ends_with("tmp"), "popd should restore cwd, got: {last}");
+    assert!(
+        !last.ends_with("tmp"),
+        "popd should restore cwd, got: {last}"
+    );
 }
 
 #[test]
@@ -379,7 +385,10 @@ fn test_dirs_shows_stack() {
     let out = shako("dirs");
     assert!(out.status.success());
     let result = stdout(&out).trim().to_string();
-    assert!(result.starts_with('/'), "dirs should show an absolute path, got: {result}");
+    assert!(
+        result.starts_with('/'),
+        "dirs should show an absolute path, got: {result}"
+    );
 }
 
 #[test]
@@ -435,7 +444,10 @@ fn test_param_strip_prefix_longest() {
     assert!(out.status.success());
     let result = stdout(&out).trim().to_string();
     // /Users/jbowman → jbowman (no slash)
-    assert!(!result.contains('/'), "## should strip longest prefix, got: {result}");
+    assert!(
+        !result.contains('/'),
+        "## should strip longest prefix, got: {result}"
+    );
 }
 
 #[test]
@@ -443,15 +455,20 @@ fn test_param_replace_first() {
     let out = shako("echo ${HOME/Users/home}");
     assert!(out.status.success());
     let result = stdout(&out).trim().to_string();
-    assert!(result.contains("home"), "/ should replace first occurrence, got: {result}");
+    assert!(
+        result.contains("home"),
+        "/ should replace first occurrence, got: {result}"
+    );
 }
-
 
 #[test]
 fn test_glob_expansion() {
     let out = shako("echo src/*.rs");
     let result = stdout(&out);
-    assert!(result.contains("main.rs"), "glob should expand src/*.rs to include main.rs");
+    assert!(
+        result.contains("main.rs"),
+        "glob should expand src/*.rs to include main.rs"
+    );
 }
 
 #[test]
@@ -526,7 +543,11 @@ fn test_builtin_type_external() {
 fn test_builtin_type_not_found() {
     let out = shako("type definitely_not_a_real_command_xyz_123");
     // /usr/bin/type exits non-zero and prints "not found" style message
-    assert!(!out.status.success() || stderr(&out).contains("not found") || stdout(&out).contains("not found"));
+    assert!(
+        !out.status.success()
+            || stderr(&out).contains("not found")
+            || stdout(&out).contains("not found")
+    );
 }
 
 // ── Phase 3: arithmetic expansion $((expr)) ────────────────────
@@ -729,7 +750,9 @@ fn test_while_loop_with_counter() {
 
 #[test]
 fn test_while_break() {
-    let out = shako(r#"export I=0; while true; do echo $I; export I=$(( I + 1 )); if [ $I -ge 2 ]; then break; fi; done"#);
+    let out = shako(
+        r#"export I=0; while true; do echo $I; export I=$(( I + 1 )); if [ $I -ge 2 ]; then break; fi; done"#,
+    );
     assert!(out.status.success());
     let s = stdout(&out);
     let lines: Vec<&str> = s.trim().lines().collect();
@@ -928,4 +951,3 @@ fn test_herestring_quoted_content() {
     assert!(out.status.success());
     assert_eq!(stdout(&out).trim(), "hello world");
 }
-


### PR DESCRIPTION
## Summary

Closes #57

- Add `/command` slash command system for inspecting and configuring shako at runtime
- Six commands: `/help`, `/validate`, `/config`, `/model`, `/safety`, `/provider`
- Classifier routes `/word` inputs to slash dispatcher (paths like `/usr/bin/ls` unaffected)
- `/safety` and `/provider` support session-only runtime changes
- Typo auto-correction now respects `confirm_ai_commands = false`

## New Files

- `src/slash.rs` — slash command dispatcher with 17 unit tests
- `docs/slash-commands.md` — full documentation with examples

## Test Plan

- [x] All 253 tests pass (140 unit + 113 integration)
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied
- [x] `/validate` tested against live endpoint
- [x] Absolute paths (`/usr/bin/ls`) still classify as `Command`
- [x] Slash commands with args parse correctly (`/safety warn`)
- [x] Unknown slash commands return error with `/help` hint


🐠 Generated with Crush