### PR TITLE
feat: animated braille spinner for AI wait states

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod setup;
 mod shell;
 mod slash;
 mod smart_defaults;
+mod spinner;
 
 use builtins::ShellState;
 use classifier::{Classification, Classifier};
@@ -587,22 +588,19 @@ fn main() -> Result<()> {
                                     || builtins::is_builtin(words[0]));
 
                             if is_bare_command {
-                                print!("\x1b[90mexplaining...\x1b[0m");
-                                io::stdout().flush().ok();
-                                rt.block_on(async {
-                                    match ai::explain_command(&text, &config).await {
-                                        Ok(explanation) => {
-                                            print!("\r\x1b[K");
-                                            eprintln!("\x1b[36m{text}\x1b[0m");
-                                            eprintln!("{explanation}");
-                                        }
-                                        Err(e) => {
-                                            print!("\r\x1b[K");
-                                            eprintln!("shako: ai error: {e}");
-                                            prompt::set_last_status(1);
-                                        }
+                                let sp = spinner::Spinner::start("explaining...");
+                                let result = rt.block_on(ai::explain_command(&text, &config));
+                                drop(sp);
+                                match result {
+                                    Ok(explanation) => {
+                                        eprintln!("\x1b[36m{text}\x1b[0m");
+                                        eprintln!("{explanation}");
                                     }
-                                });
+                                    Err(e) => {
+                                        eprintln!("shako: ai error: {e}");
+                                        prompt::set_last_status(1);
+                                    }
+                                }
                             } else {
                                 let history = read_recent_history(
                                     &history_path,
@@ -689,21 +687,18 @@ fn main() -> Result<()> {
                         if !config.behavior.ai_enabled {
                             eprintln!("shako: AI is disabled (ai_enabled = false in config)");
                         } else {
-                            print!("\x1b[90mexplaining...\x1b[0m");
-                            io::stdout().flush().ok();
-                            rt.block_on(async {
-                                match ai::explain_command(&cmd, &config).await {
-                                    Ok(explanation) => {
-                                        print!("\r\x1b[K");
-                                        eprintln!("\x1b[36m{cmd}\x1b[0m");
-                                        eprintln!("{explanation}");
-                                    }
-                                    Err(e) => {
-                                        print!("\r\x1b[K");
-                                        eprintln!("shako: ai error: {e}");
-                                    }
+                            let sp = spinner::Spinner::start("explaining...");
+                            let result = rt.block_on(ai::explain_command(&cmd, &config));
+                            drop(sp);
+                            match result {
+                                Ok(explanation) => {
+                                    eprintln!("\x1b[36m{cmd}\x1b[0m");
+                                    eprintln!("{explanation}");
                                 }
-                            });
+                                Err(e) => {
+                                    eprintln!("shako: ai error: {e}");
+                                }
+                            }
                         } // end ai_enabled check
                     }
                 }
@@ -757,82 +752,81 @@ fn offer_ai_recovery(
         return;
     }
 
-    print!("\x1b[90mthinking...\x1b[0m");
-    io::stdout().flush().ok();
+    let sp = spinner::Spinner::start("thinking...");
 
-    rt.block_on(async {
+    let result = rt.block_on(async {
         let history = read_recent_history(history_path, config.behavior.history_context_lines);
-        match ai::diagnose_error(command, exit_code, stderr_output, config, history).await {
-            Ok(response) => {
-                // Clear the "thinking..." text
-                print!("\r\x1b[K");
+        ai::diagnose_error(command, exit_code, stderr_output, config, history).await
+    });
 
-                let response = response.trim();
+    drop(sp);
 
-                // Parse CAUSE and FIX from response
-                let mut cause = String::new();
-                let mut fix = String::new();
+    match result {
+        Ok(response) => {
+            let response = response.trim();
 
-                for line in response.lines() {
-                    let line = line.trim();
-                    if let Some(c) = line.strip_prefix("CAUSE:") {
-                        cause = c.trim().to_string();
-                    } else if let Some(f) = line.strip_prefix("FIX:") {
-                        fix = f.trim().to_string();
-                    } else if !fix.is_empty() && !line.is_empty() && line != "SHAKO_NO_FIX" {
-                        // Multi-line fix
-                        fix.push('\n');
-                        fix.push_str(line);
-                    }
+            // Parse CAUSE and FIX from response
+            let mut cause = String::new();
+            let mut fix = String::new();
+
+            for line in response.lines() {
+                let line = line.trim();
+                if let Some(c) = line.strip_prefix("CAUSE:") {
+                    cause = c.trim().to_string();
+                } else if let Some(f) = line.strip_prefix("FIX:") {
+                    fix = f.trim().to_string();
+                } else if !fix.is_empty() && !line.is_empty() && line != "SHAKO_NO_FIX" {
+                    // Multi-line fix
+                    fix.push('\n');
+                    fix.push_str(line);
                 }
+            }
 
-                if !cause.is_empty() {
-                    eprintln!("\x1b[36m  cause:\x1b[0m {cause}");
-                }
+            if !cause.is_empty() {
+                eprintln!("\x1b[36m  cause:\x1b[0m {cause}");
+            }
 
-                if fix.is_empty() || fix == "SHAKO_NO_FIX" {
-                    return;
-                }
+            if fix.is_empty() || fix == "SHAKO_NO_FIX" {
+                return;
+            }
 
-                // Show suggested fix and offer to run it
-                println!("\x1b[36m  fix:\x1b[0m \x1b[1m{fix}\x1b[0m");
-                print!("\x1b[90m  [Y]es / [n]o / [e]dit:\x1b[0m ");
-                io::stdout().flush().ok();
+            // Show suggested fix and offer to run it
+            println!("\x1b[36m  fix:\x1b[0m \x1b[1m{fix}\x1b[0m");
+            print!("\x1b[90m  [Y]es / [n]o / [e]dit:\x1b[0m ");
+            io::stdout().flush().ok();
 
-                let mut answer = String::new();
-                io::stdin().read_line(&mut answer).ok();
-                let answer = answer.trim().to_lowercase();
+            let mut answer = String::new();
+            io::stdin().read_line(&mut answer).ok();
+            let answer = answer.trim().to_lowercase();
 
-                match answer.as_str() {
-                    "" | "y" | "yes" => {
-                        for line in fix.lines() {
-                            let line = line.trim();
-                            if !line.is_empty() {
-                                let status = executor::execute_command(line);
-                                set_exit_code(status);
-                            }
-                        }
-                    }
-                    "e" | "edit" => {
-                        print!("\x1b[36m  ❯\x1b[0m ");
-                        io::stdout().flush().ok();
-                        let mut edited = String::new();
-                        io::stdin().read_line(&mut edited).ok();
-                        let edited = edited.trim();
-                        if !edited.is_empty() {
-                            let status = executor::execute_command(edited);
+            match answer.as_str() {
+                "" | "y" | "yes" => {
+                    for line in fix.lines() {
+                        let line = line.trim();
+                        if !line.is_empty() {
+                            let status = executor::execute_command(line);
                             set_exit_code(status);
                         }
                     }
-                    _ => {}
                 }
-            }
-            Err(e) => {
-                print!("\r\x1b[K");
-                eprintln!("shako: ai error: {e}");
+                "e" | "edit" => {
+                    print!("\x1b[36m  ❯\x1b[0m ");
+                    io::stdout().flush().ok();
+                    let mut edited = String::new();
+                    io::stdin().read_line(&mut edited).ok();
+                    let edited = edited.trim();
+                    if !edited.is_empty() {
+                        let status = executor::execute_command(edited);
+                        set_exit_code(status);
+                    }
+                }
+                _ => {}
             }
         }
-    });
+        Err(e) => {
+            eprintln!("shako: ai error: {e}");
+        }
+    }
 }
 
 /// Check if the input line needs continuation (trailing \, unclosed quotes,

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -1,0 +1,71 @@
+use std::io::{self, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+const BRAILLE_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+pub struct Spinner {
+    running: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Spinner {
+    pub fn start(message: &str) -> Self {
+        let running = Arc::new(AtomicBool::new(true));
+        let running_clone = running.clone();
+        let msg = message.to_string();
+
+        let handle = thread::spawn(move || {
+            let mut i = 0;
+            while running_clone.load(Ordering::Relaxed) {
+                let frame = BRAILLE_FRAMES[i % BRAILLE_FRAMES.len()];
+                eprint!("\r\x1b[90m{frame} {msg}\x1b[0m");
+                io::stderr().flush().ok();
+                i += 1;
+                thread::sleep(Duration::from_millis(80));
+            }
+            eprint!("\r\x1b[K");
+            io::stderr().flush().ok();
+        });
+
+        Self {
+            running,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            handle.join().ok();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_spinner_starts_and_stops() {
+        let spinner = Spinner::start("testing...");
+        thread::sleep(Duration::from_millis(200));
+        drop(spinner);
+    }
+
+    #[test]
+    fn test_spinner_drop_stops() {
+        let spinner = Spinner::start("drop test...");
+        thread::sleep(Duration::from_millis(100));
+        drop(spinner);
+    }
+
+    #[test]
+    fn test_braille_frames_not_empty() {
+        assert!(!BRAILLE_FRAMES.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #61 (part of #50 CharmBracelet UI initiative)

- Add `src/spinner.rs` — zero-dependency animated braille spinner (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏)
- Runs on a background thread at 80ms/frame, self-clears on drop
- Replaces static text at all three AI wait points:
  - `? command` (ForcedAI explain)
  - `command?` (ExplainCommand)
  - Error recovery "thinking..."

## Before / After

**Before:** `explaining...` (static, no animation)

**After:** `⠋ explaining...` (animated braille dots cycling)

## Test Plan

- [x] `cargo clippy` clean (zero warnings)
- [x] `cargo test` — 256 tests pass (3 new spinner tests)
- [x] Spinner clears cleanly before AI output renders
- [x] Drop-based cleanup — no leaked threads


🐠 Generated with Crush