### PR TITLE
fix: use pointer arithmetic for byte-safe token slicing

### DIFF
--- a/src/builtins/state.rs
+++ b/src/builtins/state.rs
@@ -90,7 +90,12 @@ impl ShellState {
             .aliases
             .get(first_token)
             .or_else(|| self.abbreviations.get(first_token))?;
-        let rest = input[first_token.len()..].to_string();
+        // first_token is a sub-slice of input (returned by split_whitespace).
+        // Use pointer arithmetic to find its byte-end so the slice is correct
+        // even when first_token contains multi-byte characters.
+        let token_end =
+            first_token.as_ptr() as usize - input.as_ptr() as usize + first_token.len();
+        let rest = &input[token_end..];
         Some(format!("{replacement}{rest}"))
     }
 

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -130,8 +130,13 @@ impl Classifier {
         let word_count = args_after_first.len() + 1;
         if word_count <= 2 || (word_count == 3 && !looks_like_natural_language(&args_after_first)) {
             if let Some(suggestion) = self.find_typo_match(first_token) {
-                let corrected = if trimmed.len() > first_token.len() {
-                    format!("{}{}", suggestion, &trimmed[first_token.len()..])
+                // first_token is a sub-slice of trimmed; use pointer arithmetic
+                // for its byte-end so the slice is valid with multi-byte chars.
+                let token_end =
+                    first_token.as_ptr() as usize - trimmed.as_ptr() as usize + first_token.len();
+                let rest = &trimmed[token_end..];
+                let corrected = if !rest.is_empty() {
+                    format!("{suggestion}{rest}")
                 } else {
                     suggestion.clone()
                 };


### PR DESCRIPTION
## Problem (§2.2 and §2.4 from code review)

Two places sliced a string using `first_token.len()` as a raw byte offset:

**`builtins/state.rs` — `expand_alias`**
```rust
let rest = input[first_token.len()..];  // WRONG
```

**`classifier.rs` — typo correction**
```rust
format!("{}{}", suggestion, &trimmed[first_token.len()..])  // WRONG
```

In both cases `first_token` comes from `split_whitespace()` which:
1. Skips leading whitespace — so the token's byte offset from the string start is **not** `0`
2. Returns a `&str` sub-slice, so its `.len()` is a byte length, not a char count

If `first_token` contains multi-byte UTF-8 characters (e.g. a Unicode alias name), `input[first_token.len()..]` may land on a non-char-boundary and panic at runtime.

## Fix

Use pointer arithmetic to compute the correct byte end:

```rust
let token_end = first_token.as_ptr() as usize - input.as_ptr() as usize + first_token.len();
let rest = &input[token_end..];
```

`first_token` is guaranteed to be a sub-slice of `input`, so the pointer subtraction is valid.

## Files changed

- `src/builtins/state.rs` — `expand_alias`
- `src/classifier.rs` — typo correction in `classify`

https://claude.ai/code/session_019W9cWRcwU69B2Qd4zTAETp