### PR TITLE
perf: replace O(n) Vec::remove(0) and Vec::contains with O(1) equivalents

### DIFF
--- a/src/builtins/state.rs
+++ b/src/builtins/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 /// A background job tracked by the shell.
@@ -60,7 +60,8 @@ impl ShellState {
 
     /// Reap finished background jobs and report their completion.
     pub fn reap_jobs(&mut self) {
-        let mut completed = Vec::new();
+        // HashSet so the retain predicate below is O(1) per job.
+        let mut completed: HashSet<usize> = HashSet::new();
         for job in &mut self.jobs {
             match job.child.try_wait() {
                 Ok(Some(status)) => {
@@ -70,11 +71,11 @@ impl ShellState {
                     } else {
                         eprintln!("[{}] exit {code}  {}", job.id, job.command);
                     }
-                    completed.push(job.id);
+                    completed.insert(job.id);
                 }
                 Ok(None) => {} // still running
                 Err(_) => {
-                    completed.push(job.id);
+                    completed.insert(job.id);
                 }
             }
         }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, ExitStatus, Stdio};
@@ -303,23 +304,24 @@ pub fn execute_command_with_stderr(input: &str) -> (Option<ExitStatus>, String) 
             let stderr_pipe = child.stderr.take();
 
             let stderr_thread = std::thread::spawn(move || {
-                let mut collected = Vec::new();
+                // VecDeque so pop_front is O(1) instead of Vec::remove(0) O(n).
+                let mut collected: VecDeque<String> = VecDeque::new();
                 if let Some(pipe) = stderr_pipe {
                     let reader = BufReader::new(pipe);
                     for line in reader.lines() {
                         match line {
                             Ok(line) => {
                                 eprintln!("{line}");
-                                collected.push(line);
+                                collected.push_back(line);
                                 if collected.len() > 20 {
-                                    collected.remove(0);
+                                    collected.pop_front();
                                 }
                             }
                             Err(_) => break,
                         }
                     }
                 }
-                collected.join("\n")
+                collected.into_iter().collect::<Vec<_>>().join("\n")
             });
 
             let status = foreground_wait(child);


### PR DESCRIPTION
## Problems (§3.8 and §4.5 from code review)

### §3.8 — `Vec::remove(0)` is O(n) in the stderr capture thread

`execute_command_with_stderr` keeps the last 20 stderr lines for AI error diagnosis. It used a `Vec` and called `remove(0)` to drop the oldest entry:

```rust
collected.push(line);
if collected.len() > 20 {
    collected.remove(0);  // O(n) shift every time
}
```

For a command that produces thousands of stderr lines this is O(n²) overall.

### §4.5 — `Vec::contains` in `reap_jobs` is O(n) per job

```rust
self.jobs.retain(|j| !completed.contains(&j.id));  // O(jobs²)
```

## Fixes

- **executor.rs**: `Vec<String>` → `VecDeque<String>`, `push` → `push_back`, `remove(0)` → `pop_front` — both O(1).
- **builtins/state.rs**: `Vec<usize>` → `HashSet<usize>`, `push` → `insert`, `contains` → `HashSet::contains` — O(1) lookup.

https://claude.ai/code/session_019W9cWRcwU69B2Qd4zTAETp