### PR TITLE
fix: misc defects — thread panic logging, for-loop local scope, rm false positive

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -457,8 +457,11 @@ fn exec_one(stmt: &Statement, locals: &mut Vec<(String, Option<String>)>) -> Exe
         } => {
             let items = crate::parser::parse_args(items_expr);
             let mut last = 0i32;
+            // Save the loop variable's pre-loop value once, before the first
+            // iteration. Calling declare_local inside the loop would push
+            // redundant save entries on every iteration.
+            declare_local(var, locals);
             'for_loop: for item in &items {
-                declare_local(var, locals);
                 unsafe { std::env::set_var(var, item) };
                 match exec_statements(body, locals) {
                     ExecSignal::Normal(c) => last = c,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -63,7 +63,10 @@ fn foreground_wait(mut child: std::process::Child) -> std::process::ExitStatus {
     // Give the terminal to the child so Ctrl-C/Ctrl-Z reach it.
     let _ = nix::unistd::tcsetpgrp(std::io::stdin(), child_pid);
 
-    let status = child.wait().unwrap_or_else(|_| fake_status(1));
+    let status = child.wait().unwrap_or_else(|e| {
+        log::warn!("wait() failed for child process: {e}");
+        fake_status(1)
+    });
 
     // Restore terminal ownership to the shell.
     let _ = nix::unistd::tcsetpgrp(std::io::stdin(), shell_pgid);
@@ -323,7 +326,15 @@ pub fn execute_command_with_stderr(input: &str) -> (Option<ExitStatus>, String) 
             });
 
             let status = foreground_wait(child);
-            let stderr_output = stderr_thread.join().unwrap_or_default();
+            let stderr_output = match stderr_thread.join() {
+                Ok(s) => s,
+                Err(_) => {
+                    log::warn!(
+                        "stderr capture thread panicked; AI error diagnosis may be incomplete"
+                    );
+                    String::new()
+                }
+            };
 
             if !status.success() {
                 if let Some(code) = status.code() {

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -21,8 +21,14 @@ pub fn is_dangerous(command: &str) -> bool {
 /// Check if an AI-generated command should get extra confirmation.
 pub fn needs_extra_confirmation(command: &str) -> bool {
     let lower = command.to_lowercase();
+    // Use word-boundary checks for "rm" to avoid false positives on commands
+    // like `arm` whose lowercase form contains the substring "rm ".
+    let has_rm = lower == "rm"
+        || lower.starts_with("rm ")
+        || lower.contains(" rm ")
+        || lower.contains("\trm ");
     lower.contains("sudo")
-        || lower.contains("rm ")
+        || has_rm
         || lower.contains("mv /")
         || lower.contains("chmod")
         || lower.contains("chown")


### PR DESCRIPTION
Four small independent fixes bundled together.

## §1.4 — Log stderr thread panics (executor.rs)

`stderr_thread.join().unwrap_or_default()` silently swallowed panics in the thread that captures stderr for AI error diagnosis. A broken pipe or any other panic would result in empty stderr being reported to the AI, giving a useless or wrong diagnosis. Now logs a `warn!` so the issue is visible.

## §4.6 — Log `wait()` failures in `foreground_wait` (executor.rs)

`child.wait().unwrap_or_else(|_| fake_status(1))` discarded the OS error. The cause is now logged at `warn!` level before the fallback.

## §2.5 — Move `declare_local` outside the for loop (control.rs)

`declare_local(var, locals)` was called on every loop iteration. The function already guards against duplicates, so only the first call has any effect — but subsequent calls still walked the `locals` vec to check for the duplicate. Moving the call before the loop makes the intent clear and avoids the redundant work on every iteration.

## §4.2 — Fix `"rm "` false positive in safety layer (safety.rs)

`lower.contains("rm ")` matches commands like `arm -v` because `"arm "` contains `"rm "` as a substring. Replaced with explicit word-boundary checks:

```rust
let has_rm = lower == "rm"
    || lower.starts_with("rm ")
    || lower.contains(" rm ")
    || lower.contains("\trm ");
```

https://claude.ai/code/session_019W9cWRcwU69B2Qd4zTAETp