### PR TITLE
fix: resolve #101 — bug: unsafe env::set_var scattered across 7 files with no centralized safety enforcement

### DIFF
--- a/src/builtins/env.rs
+++ b/src/builtins/env.rs
@@ -6,7 +6,7 @@
 pub fn builtin_export(args: &[&str]) {
     for arg in args {
         if let Some((key, value)) = arg.split_once('=') {
-            unsafe { std::env::set_var(key, value) };
+            crate::env_guard::set_var(key, value);
         } else {
             match std::env::var(arg) {
                 Ok(val) => println!("{arg}={val}"),
@@ -19,6 +19,6 @@ pub fn builtin_export(args: &[&str]) {
 /// `unset` — remove environment variables.
 pub fn builtin_unset(args: &[&str]) {
     for arg in args {
-        unsafe { std::env::remove_var(arg) };
+        crate::env_guard::remove_var(arg);
     }
 }


### PR DESCRIPTION
## Summary

This file contains 2 calls to `unsafe { std::env::set_var() }` and/or `unsafe { std::env::remove_var() }`. Replace them with `crate::env_guard::set_var()` and `crate::env_guard::remove_var()` respectively. Remove the unsafe blocks entirely

Fixes #101

## Changes

- `src/builtins/env.rs`

## Why

`src/builtins/env.rs`: This file contains 2 calls to `unsafe { std::env::set_var() }` and/or `unsafe { std::env::remove_var() }`. Replace them with `crate::env_guard::set_var()` and `crate::env_guard::remove_var()` respectively. Remove the unsafe blocks entirely.
